### PR TITLE
Fix: exclude slow tests from CI (was hanging 1.5h+)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,4 @@ jobs:
         run: python -m pip list
 
       - name: Test with PyTest
-        run: python -m pytest -v -rsx tests
+        run: python -m pytest -v -rsx tests -m "not slow"


### PR DESCRIPTION
## Summary
- `main`'s CI is currently broken: the push that added the `slow` pytest marker (`pyproject.toml`, commit 4438520) never updated this workflow to actually pass `-m "not slow"`, so every push runs the full suite including all 28 `TestPretrainedVariants` cases, which download real pretrained checkpoints from the Hugging Face Hub.
- Run [29124462888](https://github.com/shriarul5273/depth_estimation/actions/runs/29124462888) took 1h29m and had to be manually cancelled partway through (only ~half the 28 variants had finished downloading).
- One-line fix: add `-m "not slow"` to the pytest invocation, matching the intent of the marker that was already registered.

## Test plan
- [x] Confirmed `main`'s current workflow file lacks the filter (`git show origin/main:.github/workflows/test.yml`).
- [x] Confirmed the offline/fast suite (what remains after filtering) runs in under 2 minutes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)