### PR TITLE
Fix 3 bugs found while auditing device handling

### DIFF
--- a/src/depth_estimation/data/nyu_depth_v2.py
+++ b/src/depth_estimation/data/nyu_depth_v2.py
@@ -155,7 +155,10 @@ class NYUDepthV2Dataset(BaseDepthDataset):
         return image, depth.astype(np.float32)
 
     def __del__(self) -> None:
-        if self._h5 is not None:
+        # getattr guard: __init__ may raise before self._h5 is assigned
+        # (e.g. missing dataset file), in which case __del__ still runs
+        # during garbage collection.
+        if getattr(self, "_h5", None) is not None:
             try:
                 self._h5.close()
             except Exception:

--- a/src/depth_estimation/models/marigold_dc/modeling_marigold_dc.py
+++ b/src/depth_estimation/models/marigold_dc/modeling_marigold_dc.py
@@ -15,7 +15,7 @@ import torch
 import torch.nn.functional as F
 from PIL import Image
 
-from ...modeling_utils import BaseDepthModel, _auto_detect_device
+from ...modeling_utils import BaseDepthModel
 from .configuration_marigold_dc import MarigoldDCConfig
 
 logger = logging.getLogger(__name__)
@@ -73,7 +73,7 @@ class MarigoldDCModel(BaseDepthModel):
             )
         from diffusers import MarigoldDepthPipeline, DDIMScheduler
 
-        device = torch.device(_auto_detect_device())
+        device = self.device
         dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
 
         pipe = MarigoldDepthPipeline.from_pretrained(
@@ -299,6 +299,7 @@ class MarigoldDCModel(BaseDepthModel):
         """Load Marigold-DC model."""
         config = MarigoldDCConfig()
         model = cls(config)
+        model = model.to(device)
         model._ensure_pipe()
 
         logger.info(f"Loaded Marigold-DC from {config.hub_model_id}")

--- a/src/depth_estimation/models/zoedepth/modeling_zoedepth.py
+++ b/src/depth_estimation/models/zoedepth/modeling_zoedepth.py
@@ -56,7 +56,7 @@ class ZoeDepthModel(BaseDepthModel):
                 "ZoeDepth requires the `transformers` package. "
                 "Install with: pip install transformers"
             )
-        device_id = 0 if self._device_str == "cuda" else -1
+        device_id = 0 if self.device.type == "cuda" else -1
         self._pipeline = hf_pipeline(
             task="depth-estimation",
             model=self.config.hf_model_id,
@@ -120,7 +120,7 @@ class ZoeDepthModel(BaseDepthModel):
 
         config = ZoeDepthConfig(backbone=backbone)
         model = cls(config)
-        model._device_str = device
+        model = model.to(device)
         model._ensure_pipeline()
 
         logger.info(f"Loaded ZoeDepth from {config.hf_model_id}")


### PR DESCRIPTION
## Summary
Follow-up audit after #6 (DepthPro device fix) — checked every model family for the same class of bug, and found two more real issues plus one unrelated cosmetic bug that's shown up in every test run.

1. **`marigold_dc`** — same bug as DepthPro: `_ensure_pipe()` called `_auto_detect_device()` directly, ignoring the model's actual device. Worse, `_load_pretrained_weights()` built the diffusers pipeline *before* `.to(device)` was ever called, so even the documented `from_pretrained` path never respected the requested device (and diffusers pipelines aren't real `nn.Module` submodules, so a later `.to()` wouldn't have fixed it either). Now threads `self.device` through correctly (set via `.to(device)` before `_ensure_pipe()` runs).
2. **`zoedepth`** — `self._device_str` was only ever set inside `_load_pretrained_weights`; constructing `ZoeDepthModel(config)` directly and calling `forward()` crashed with `AttributeError: no attribute '_device_str'`. Replaced with the same `self.device` property from #6.
3. **`NYUDepthV2Dataset.__del__`** — accessed `self._h5` unguarded; if `__init__` raises before that attribute is set (which `test_download_datasets_require_network` does on purpose), garbage collection later throws `AttributeError`. This is the warning that's appeared in every full test run this session. Fixed with a `getattr` guard.

Checked `moge`, `vggt`, `omnivggt`, `midas` too — all correct, no changes needed (they either build `_net` only inside `_load_pretrained_weights` with an explicit device, or are real `nn.Module`s that participate in `.to()` natively).

## Test plan
- [x] Full fast suite (`pytest -m "not slow"`, 329 tests) passes — **0 warnings**, confirming the `__del__` fix (previously 1 warning every run).
- [x] Verified `marigold_dc`/`zoedepth`'s `device` property correctly reflects `.to("cpu")` before any pipeline is built (can't fully exercise `_ensure_pipe()`/`_ensure_pipeline()` without triggering real downloads, out of scope here).