### PR TITLE
Pin weights_only=True on external checkpoint loads

### DIFF
--- a/src/depth_estimation/models/depth_pro/modeling_depth_pro.py
+++ b/src/depth_estimation/models/depth_pro/modeling_depth_pro.py
@@ -214,7 +214,7 @@ def create_vit(
         model.model = _resize_vit(model.model, img_size=img_size)
 
     if checkpoint_uri is not None:
-        state_dict = torch.load(checkpoint_uri, map_location="cpu")
+        state_dict = torch.load(checkpoint_uri, map_location="cpu", weights_only=True)
         missing_keys, unexpected_keys = model.load_state_dict(
             state_dict=state_dict, strict=False
         )
@@ -885,7 +885,7 @@ class DepthProModel(BaseDepthModel):
             filename=config.hub_filename,
             repo_type="model",
         )
-        state_dict = torch.load(checkpoint_path, map_location="cpu")
+        state_dict = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
         missing_keys, unexpected_keys = net.load_state_dict(
             state_dict=state_dict, strict=True
         )

--- a/src/depth_estimation/models/pixel_perfect_depth/modeling_ppd.py
+++ b/src/depth_estimation/models/pixel_perfect_depth/modeling_ppd.py
@@ -940,7 +940,7 @@ class PixelPerfectDepthModel(BaseDepthModel):
             filename=config.semantics_hub_filename,
             repo_type="model",
         )
-        da_v2_state = torch.load(da_v2_path, map_location="cpu")
+        da_v2_state = torch.load(da_v2_path, map_location="cpu", weights_only=True)
         missing, unexpected = net.semantics_encoder.load_state_dict(
             da_v2_state, strict=False
         )
@@ -957,7 +957,7 @@ class PixelPerfectDepthModel(BaseDepthModel):
             filename=config.hub_filename,
             repo_type="model",
         )
-        ppd_state = torch.load(ppd_path, map_location="cpu")
+        ppd_state = torch.load(ppd_path, map_location="cpu", weights_only=True)
         missing, unexpected = net.load_state_dict(ppd_state, strict=False)
         logger.info(
             "Loaded PPD checkpoint from %s (missing=%d, unexpected=%d)",

--- a/src/depth_estimation/models/zoedepth/modeling_zoedepth.py
+++ b/src/depth_estimation/models/zoedepth/modeling_zoedepth.py
@@ -56,7 +56,9 @@ class ZoeDepthModel(BaseDepthModel):
                 "ZoeDepth requires the `transformers` package. "
                 "Install with: pip install transformers"
             )
-        device_id = 0 if self.device.type == "cuda" else -1
+        device_id = -1
+        if self.device.type == "cuda":
+            device_id = self.device.index if self.device.index is not None else 0
         self._pipeline = hf_pipeline(
             task="depth-estimation",
             model=self.config.hf_model_id,


### PR DESCRIPTION
## Summary

**1. Pin `weights_only=True` on external checkpoint loads (DepthPro, PixelPerfectDepth)**

Both loaded their HuggingFace Hub checkpoints via `torch.load(...)` without specifying `weights_only`, unlike every other model in this codebase (`depth_anything_v2`, `moge`, `trainer.py`'s model-weights load) which already pin `weights_only=True` explicitly.

Two real issues from leaving it unset:
- **Security** — unpickling without `weights_only=True` can execute arbitrary code embedded in a malicious checkpoint.
- **Cross-version compat** — torch changed the *default* value of `weights_only` from `False` to `True` in 2.6. Leaving it unset meant these two paths would silently behave differently depending on which torch version loads them — exactly the kind of drift the torch-version CI matrix (#3) exists to catch, except this path isn't covered by that matrix since it needs a real download (network/`slow` tier, never actually run).

Both call sites immediately do `net.load_state_dict(state_dict)` right after `torch.load()`, which already requires the loaded object to be a flat `dict[str, Tensor]` — exactly what `weights_only=True` allows, so this should be a no-op for well-formed checkpoints (not independently verified against a live download — would require pulling several GB of weights).

`trainer.py`'s `weights_only=False` (loading its own `training_state.pt`) is intentionally left alone — self-generated, trusted local checkpoint containing non-tensor optimizer/scheduler state, not an external download.

**2. Fix ZoeDepth ignoring the GPU index on multi-GPU machines**

`device_id = 0 if self.device.type == "cuda" else -1` always dispatched the HF pipeline to GPU 0, ignoring the actual requested device index — e.g. `device="cuda:1"` would silently still run on GPU 0. Now uses `self.device.index` (falling back to 0 for a bare `"cuda"` device with no explicit index, matching prior behavior for the common single-GPU case).

## Test plan
- [x] Full fast suite (`pytest -m "not slow"`) passes — these code paths aren't reached by the offline test tier, so both changes are low-risk and narrowly scoped.
- [x] Verified `torch.device("cuda:1").index == 1` and `torch.device("cuda").index is None` (falls back to 0) match the intended logic.
- [ ] Checkpoint-loading change not verified against a live download (would require several GB).