### PR TITLE
Add 4 CI/CD improvements: lint, build check, concurrency, scheduled slow tests

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,0 +1,44 @@
+# Runs the tests excluded from the main CI workflow (pytest -m slow):
+# the offline-but-compute-heavy DepthPro/PixelPerfectDepth cases, and —
+# most importantly — all 28 registered model variants with real pretrained
+# weights downloaded from the Hugging Face Hub. These are slow (network,
+# several GB of downloads) so they don't run on every push/PR; instead
+# this runs on a weekly schedule to catch real regressions eventually,
+# plus workflow_dispatch for an on-demand run.
+
+name: Slow tests
+
+on:
+  schedule:
+    # Every Monday at 04:00 UTC.
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  slow:
+    name: slow tests (pretrained + offline-heavy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v6.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.1.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Show installed packages
+        run: python -m pip list
+
+      - name: Run slow tests
+        run: python -m pytest -v -rsx tests -m slow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,8 @@
 # This workflow runs the test suite across a matrix of Python versions and
 # torch versions on GitHub Actions — 3 Python versions x 3 torch "branches"
 # (our declared floor, the old hard-pinned version, and unpinned-latest),
-# to catch both Python-compat and torch-compat breaks.
+# to catch both Python-compat and torch-compat breaks. It also lints with
+# ruff and does a smoke build of the package on every push/PR.
 
 name: CI
 
@@ -15,7 +16,52 @@ on:
 permissions:
   contents: read
 
+# Cancel a still-running CI run for this branch/PR when a new commit is
+# pushed, instead of letting superseded runs finish and waste CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint:
+    name: lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.1.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install ruff
+        run: python -m pip install ruff
+
+      - name: Run ruff check
+        run: ruff check .
+
+  build:
+    name: build (smoke test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.1.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build tooling
+        run: python -m pip install build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check package metadata
+        run: twine check dist/*
+
   test:
     name: test (py${{ matrix.python-version }}, torch==${{ matrix.torch-version || 'latest' }})
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,9 @@ where = ["src"]
 markers = [
     "slow: heavy or network-dependent tests, excluded by default (run with -m slow)",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Model submodules are imported for their self-registration side effect
+# (they call MODEL_REGISTRY.register(...) at import time) — not because
+# their names are used directly here.
+"src/depth_estimation/__init__.py" = ["F401"]

--- a/src/depth_estimation/models/depth_anything_v2/modeling_depth_anything_v2.py
+++ b/src/depth_estimation/models/depth_anything_v2/modeling_depth_anything_v2.py
@@ -465,7 +465,9 @@ class DinoVisionTransformer(nn.Module):
         elif ffn_layer in ("swiglufused", "swiglu"):
             ffn_layer_cls = SwiGLUFFNFused
         elif ffn_layer == "identity":
-            ffn_layer_cls = lambda *args, **kwargs: nn.Identity()
+
+            def ffn_layer_cls(*args, **kwargs):
+                return nn.Identity()
         else:
             raise NotImplementedError(f"Unknown ffn_layer: {ffn_layer}")
 

--- a/src/depth_estimation/models/depth_anything_v3/modeling_depth_anything_v3.py
+++ b/src/depth_estimation/models/depth_anything_v3/modeling_depth_anything_v3.py
@@ -838,6 +838,12 @@ class DinoVisionTransformer(nn.Module):
     ):
         B, S, _, H, W = x.shape
         x = self.prepare_tokens_with_masks(x)
+        # Tracks the running "local" x for the cat_token head and for the
+        # reference-view reorder below; only meaningfully overwritten once
+        # the loop reaches a local-attention block (see `local_x = x` below),
+        # but must be bound here so the reorder is well-defined even if a
+        # future alt_start=0/1 config reaches it before that first write.
+        local_x = x
         output, total_block_len, aux_output = [], len(self.blocks), []
         blocks_to_take = (
             range(total_block_len - n, total_block_len) if isinstance(n, int) else n

--- a/src/depth_estimation/models/marigold_dc/modeling_marigold_dc.py
+++ b/src/depth_estimation/models/marigold_dc/modeling_marigold_dc.py
@@ -23,9 +23,11 @@ logger = logging.getLogger(__name__)
 
 def _check_diffusers_available():
     try:
-        from diffusers import MarigoldDepthPipeline, DDIMScheduler
+        import diffusers
 
-        return True
+        return hasattr(diffusers, "MarigoldDepthPipeline") and hasattr(
+            diffusers, "DDIMScheduler"
+        )
     except ImportError:
         return False
 

--- a/src/depth_estimation/models/moge/modeling_moge.py
+++ b/src/depth_estimation/models/moge/modeling_moge.py
@@ -564,8 +564,11 @@ class _Block(nn.Module):
         self.sample_drop_ratio = drop_path
 
     def forward(self, x: Tensor) -> Tensor:
-        attn_res = lambda x: self.ls1(self.attn(self.norm1(x)))
-        ffn_res = lambda x: self.ls2(self.mlp(self.norm2(x)))
+        def attn_res(x):
+            return self.ls1(self.attn(self.norm1(x)))
+
+        def ffn_res(x):
+            return self.ls2(self.mlp(self.norm2(x)))
         if self.training and self.sample_drop_ratio > 0.1:
             x = _drop_add_residual_stochastic_depth(x, attn_res, self.sample_drop_ratio)
             x = _drop_add_residual_stochastic_depth(x, ffn_res, self.sample_drop_ratio)
@@ -582,10 +585,13 @@ class _NestedTensorBlock(_Block):
     def forward_nested(self, x_list):
         assert isinstance(self.attn, _MemEffAttention)
         if self.training and self.sample_drop_ratio > 0.0:
-            attn_res = lambda x, attn_bias=None: self.attn(
-                self.norm1(x), attn_bias=attn_bias
-            )
-            ffn_res = lambda x, attn_bias=None: self.mlp(self.norm2(x))
+
+            def attn_res(x, attn_bias=None):
+                return self.attn(self.norm1(x), attn_bias=attn_bias)
+
+            def ffn_res(x, attn_bias=None):
+                return self.mlp(self.norm2(x))
+
             sv1 = self.ls1.gamma if isinstance(self.ls1, _LayerScale) else None
             sv2 = self.ls2.gamma if isinstance(self.ls1, _LayerScale) else None
             x_list = _drop_add_residual_stochastic_depth_list(
@@ -596,10 +602,13 @@ class _NestedTensorBlock(_Block):
             )
             return x_list
         else:
-            attn_res = lambda x, attn_bias=None: self.ls1(
-                self.attn(self.norm1(x), attn_bias=attn_bias)
-            )
-            ffn_res = lambda x, attn_bias=None: self.ls2(self.mlp(self.norm2(x)))
+
+            def attn_res(x, attn_bias=None):
+                return self.ls1(self.attn(self.norm1(x), attn_bias=attn_bias))
+
+            def ffn_res(x, attn_bias=None):
+                return self.ls2(self.mlp(self.norm2(x)))
+
             attn_bias, x = _get_attn_bias_and_cat(x_list)
             x = x + attn_res(x, attn_bias=attn_bias)
             x = x + ffn_res(x)
@@ -715,7 +724,9 @@ class _DinoVisionTransformer(nn.Module):
         elif ffn_layer in ("swiglufused", "swiglu"):
             ffn_cls = _SwiGLUFFNFused
         elif ffn_layer == "identity":
-            ffn_cls = lambda *a, **kw: nn.Identity()
+
+            def ffn_cls(*a, **kw):
+                return nn.Identity()
         else:
             raise NotImplementedError(ffn_layer)
 
@@ -1959,11 +1970,6 @@ class _MoGeModelV2(nn.Module):
             )
 
         features = self.neck(features)
-
-        points = getattr(self, "points_head", None)
-        normal = getattr(self, "normal_head", None)
-        mask = getattr(self, "mask_head", None)
-        scale = getattr(self, "scale_head", None)
 
         points = (
             self.points_head(features)[-1] if hasattr(self, "points_head") else None

--- a/src/depth_estimation/models/omnivggt/modeling_omnivggt.py
+++ b/src/depth_estimation/models/omnivggt/modeling_omnivggt.py
@@ -529,7 +529,9 @@ class DinoVisionTransformer(nn.Module):
         elif ffn_layer in ("swiglufused", "swiglu"):
             ffn_layer_cls = SwiGLUFFNFused
         elif ffn_layer == "identity":
-            ffn_layer_cls = lambda **kw: nn.Identity()
+
+            def ffn_layer_cls(**kw):
+                return nn.Identity()
         else:
             raise NotImplementedError
 

--- a/src/depth_estimation/models/vggt/modeling_vggt.py
+++ b/src/depth_estimation/models/vggt/modeling_vggt.py
@@ -512,7 +512,9 @@ class DinoVisionTransformer(nn.Module):
         elif ffn_layer in ("swiglufused", "swiglu"):
             ffn_layer_cls = SwiGLUFFNFused
         elif ffn_layer == "identity":
-            ffn_layer_cls = lambda **kw: nn.Identity()
+
+            def ffn_layer_cls(**kw):
+                return nn.Identity()
         else:
             raise NotImplementedError
 

--- a/src/depth_estimation/video.py
+++ b/src/depth_estimation/video.py
@@ -217,8 +217,7 @@ def process_video(
     src_fps = fps or stream.fps
     total = stream.total_frames
 
-    # Determine output frame size from first frame
-    first_frame_rgb = None
+    # Output writer is lazily initialised once the first frame's size is known.
     out_writer = None
 
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -255,7 +255,9 @@ class TestLoadDataset:
         img_dir.mkdir()
         _write_rgb(img_dir / "a.png")
 
-        identity = lambda pv, dm, vm: (pv, dm, vm)
+        def identity(pv, dm, vm):
+            return pv, dm, vm
+
         ds = load_dataset("folder", image_dir=str(img_dir), transform=identity)
         assert ds.transform is identity
 


### PR DESCRIPTION
## Summary

**1. ruff lint check in CI**
Nothing previously enforced `ruff check` — a `.ruff_cache/` and past commit ("ruff check fix reformats") show it's used locally, but CI never ran it, so nothing stopped regressions. Found 24 pre-existing violations when I ran it against the whole repo (first commit fixes all of them, see below); this commit adds the actual CI job.

**2. Build smoke-test on every PR**
`python-publish.yml` only runs `python -m build` when a release is published — a packaging/metadata mistake wouldn't surface until you're actually cutting a release. Added a job that builds the sdist+wheel and runs `twine check` on every push/PR.

**3. Concurrency cancellation**
A new push to a branch/PR now cancels that ref's in-progress run instead of letting a superseded run keep consuming CI minutes (relevant — I pushed multiple times to several of the PRs from this session).

**4. Scheduled weekly run of the slow test tier**
`pytest -m slow` (offline-heavy DepthPro/PixelPerfectDepth cases + all 28 registered model variants with real pretrained weights) has never run anywhere — it's excluded from every push/PR by design (network, several GB of downloads). New `slow-tests.yml` runs it weekly (Monday 04:00 UTC) plus `workflow_dispatch` for on-demand runs, so regressions there get caught eventually.

## Pre-existing lint fixes (first commit, prerequisite for #1)
- **Real bug (not just style)**: `depth_anything_v3/modeling_depth_anything_v3.py` — `local_x` was read before its only assignment (F821), inside a mid-loop reference-view reorder. Not currently reachable for any registered backbone config (`alt_start` is always ≥ 4, so prior loop iterations always bind it first), but fragile — initialized `local_x = x` before the loop so it's correct regardless of config, not just correct-by-luck.
- `__init__.py`: 11× F401 for intentional model-registration side-effect imports — added a `per-file-ignore` in `pyproject.toml` rather than touching the imports (removing them would break model registration).
- 10× E731 (lambda assigned to a variable) across `depth_anything_v2`, `moge`, `omnivggt`, `vggt` — mechanical rewrite to `def`, no behavior change.
- 2× F841 (unused local variable): both genuinely dead code — `moge`'s `scale`/`points`/`normal`/`mask` were immediately reassigned by the following block; `video.py`'s `first_frame_rgb` was never read (output size is actually computed per-frame inside the loop). Removed both.

## Test plan
- [x] `ruff check .` passes clean across the whole repo.
- [x] Full fast suite (`pytest -m "not slow"`, 329 tests) passes after all the mechanical rewrites.
- [x] `depth_anything_v3` offline test (`TestFastOffline::test_depth_anything_v3_small`) still passes after the `local_x` fix.
- [x] Verified locally: `python -m build` + `twine check dist/*` both pass.
- [x] Validated YAML syntax of both workflow files, and TOML syntax of the `pyproject.toml` change.