### PR TITLE
Fix stale docs: torch pin, and a nonexistent [data] extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # depth_estimation
 
 <p align="center">
+    <a href="https://github.com/shriarul5273/depth_estimation/actions/workflows/test.yml"><img alt="CI" src="https://github.com/shriarul5273/depth_estimation/actions/workflows/test.yml/badge.svg"></a>
     <a href="https://github.com/shriarul5273/depth_estimation/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/shriarul5273/depth_estimation?color=blue"></a>
     <a href="https://pypi.org/project/depth-estimation/"><img alt="PyPI" src="https://img.shields.io/pypi/v/depth-estimation"></a>
     <a href="https://pypi.org/project/depth-estimation/"><img alt="Python" src="https://img.shields.io/pypi/pyversions/depth-estimation"></a>

--- a/docs/data.md
+++ b/docs/data.md
@@ -89,7 +89,7 @@ Indoor RGB-D dataset captured with a Microsoft Kinect. The labeled set contains 
 - `nyu_depth_v2_labeled.mat` — all 1 449 labeled samples (~2.8 GB)
 - `splits.mat` — official Eigen train/test split (795 train / 654 test)
 
-**Requires:** `h5py` — `pip install "depth-estimation[data]"`
+**Requires:** `h5py` (already a core dependency — installed automatically)
 
 ```python
 load_dataset("nyu_depth_v2", split="test")
@@ -234,18 +234,10 @@ Transforms must accept and return `(pixel_values, depth_map, valid_mask)` tuples
 
 ## Installation
 
-Core dataset functionality (folder, KITTI, DIODE) requires only `Pillow` and `numpy`, which are already core dependencies.
-
-NYU Depth V2 additionally requires `h5py`:
+All dataset loaders, including NYU Depth V2's `h5py` dependency, work out of the box with:
 
 ```bash
-pip install "depth-estimation[data]"
+pip install depth-estimation
 ```
 
-Or install manually:
-
-```bash
-pip install h5py tqdm
-```
-
-The `tqdm` package is optional — download progress falls back to a plain `print` when it is not installed.
+`h5py` and `tqdm` are core dependencies — no extra install step or optional extra needed. (`tqdm` is used for download progress bars; if it were ever missing, downloads fall back to a plain `print`.)

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -7,7 +7,7 @@ These are installed automatically with `pip install depth-estimation`
 | Package | Version Constraint | Notes |
 |---|---|---|
 | Python | `>=3.10` | 3.10 – 3.12 supported |
-| torch | `==2.10.0` | Pinned release |
+| torch | `>=2.0` | Not hard-pinned — installs alongside your existing torch (GPU or CPU) instead of forcing a specific version. See [issue #1](https://github.com/shriarul5273/depth_estimation/issues/1). |
 | torchvision | `>=0.15` | |
 | Pillow | `>=9.0` | |
 | NumPy | `>=1.24` | |
@@ -20,12 +20,13 @@ These are installed automatically with `pip install depth-estimation`
 | timm | `>=0.9.1` | |
 | einops | `>=0.6` | |
 | addict | (any) | |
+| h5py | (any) | Required for NYU Depth V2 — already a core dependency, no extra needed |
+| tqdm | (any) | Download progress bars |
 
 ## Extras
 
 | Extra | Install command | Required for |
 |---|---|---|
-| `data` | `pip install "depth-estimation[data]"` | NYU Depth V2 (h5py) |
 | `dev` | `pip install "depth-estimation[dev]"` | Running tests |
 
 ## Development Dependencies


### PR DESCRIPTION
## Summary
Found while looking for more improvements — the docs never got updated when the torch pin was actually removed (#1's fix).

- `docs/dependencies.md` still said `torch == 2.10.0 (Pinned release)` — directly contradicting the real fix (`torch>=2.0`, unpinned). Updated and linked back to #1.
- `docs/dependencies.md` and `docs/data.md` both told users to run `pip install "depth-estimation[data]"` for NYU Depth V2's `h5py` dependency — but no `data` extra exists in `pyproject.toml` (only `dev` does). `h5py` and `tqdm` are already unconditional core dependencies, so this documented command would either error on modern pip or be a confusing no-op. Rewrote both to state the actual behavior: plain `pip install depth-estimation` already includes everything needed.
- Added a CI status badge to the README — there wasn't one despite the CI setup this repo now has (test matrix + lint + build, from #11).

Also spot-checked `docs/models.md`'s variant table against the actual registry (28 variants) — that one's accurate, no changes needed there.

## Test plan
- [x] Full fast suite (`pytest -m "not slow"`, 362 tests) still passes — doc-only change, no source touched besides README/docs.