### PR TITLE
Fix __version__ drift by reading it from package metadata

### DIFF
--- a/src/depth_estimation/__init__.py
+++ b/src/depth_estimation/__init__.py
@@ -148,4 +148,11 @@ __all__ = [
     "viz",
 ]
 
-__version__ = "0.0.9"
+try:
+    from importlib.metadata import PackageNotFoundError, version
+
+    __version__ = version("depth_estimation")
+except PackageNotFoundError:
+    # Package not installed (e.g. running from a source checkout without
+    # `pip install -e .`) — no metadata to read the version from.
+    __version__ = "0.0.0+unknown"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,20 @@
+"""Tests for top-level depth_estimation package metadata."""
+
+from importlib.metadata import version as installed_version
+
+import depth_estimation
+
+
+def test_version_matches_installed_metadata():
+    """depth_estimation.__version__ must match what pip/PyPI report for the
+    installed distribution. This used to be a value hardcoded independently
+    in __init__.py, which drifted out of sync with pyproject.toml (0.0.9 vs
+    0.1.1) — now it's read dynamically from package metadata instead, so
+    there's only one place the version is declared.
+    """
+    assert depth_estimation.__version__ == installed_version("depth_estimation")
+
+
+def test_version_is_nonempty_string():
+    assert isinstance(depth_estimation.__version__, str)
+    assert len(depth_estimation.__version__) > 0


### PR DESCRIPTION
## Summary
- `depth_estimation.__version__` was hardcoded to `"0.0.9"` while `pyproject.toml`'s actual version is `"0.1.1"` — two releases out of sync. `git log -p` on `__init__.py` shows this has drifted before (bumped manually and independently in both places each time it changed).
- Root-cause fix: derive `__version__` from `importlib.metadata.version("depth_estimation")` instead of hardcoding a second copy — so there's only one place the version is ever declared (`pyproject.toml`), and this class of drift becomes structurally impossible rather than just fixed-for-now.
- Adds `tests/test_package.py` to catch this going forward — asserts `__version__` matches what pip/PyPI would actually report for the installed distribution (deliberately avoids `tomllib`, which is Python 3.11+ only and would break on the 3.10 CI matrix job).

## Test plan
- [x] `depth_estimation.__version__` now correctly reports `0.1.1`.
- [x] New tests pass; full fast suite (364 tests) passes.
- [x] `ruff check` clean.