### PR TITLE
Fix broken import example + 3 doc/code gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ See [docs/evaluation.md](https://github.com/shriarul5273/depth_estimation/blob/m
 <summary><b>Fine-Tuning</b> — any trainable model, any depth dataset</summary>
 
 ```python
-from depth_estimation import DepthAnythingV2Model, DepthTrainer, DepthTrainingArguments, load_dataset
+from depth_estimation import DepthTrainer, DepthTrainingArguments, load_dataset
+from depth_estimation.models.depth_anything_v2 import DepthAnythingV2Model
 from depth_estimation.data.transforms import get_train_transforms, get_val_transforms
 
 model    = DepthAnythingV2Model.from_pretrained("depth-anything-v2-vits", for_training=True)

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -91,11 +91,12 @@ compare(
     models: list[str],
     dataset: str | BaseDepthDataset,
     num_samples: int = None,
+    print_table: bool = True,
     ...same remaining args as evaluate()...
 ) -> dict[str, dict]
 ```
 
-Evaluates each model in `models` on the same dataset and prints a formatted comparison table. Returns `{model_id: metrics_dict}`.
+Evaluates each model in `models` on the same dataset. `print_table` controls whether the formatted comparison table below is printed (set `False` to compute results silently). Returns `{model_id: metrics_dict}`.
 
 ```python
 from depth_estimation.evaluation import compare
@@ -199,10 +200,11 @@ p = profile_latency(
     num_warmup=10,
     num_runs=100,
     device="cuda",
+    half=False,   # cast model + input to FP16 before timing
 )
 ```
 
-Returns `mean_ms`, `std_ms`, `min_ms`, `max_ms`, `p50_ms`, `p95_ms`, `p99_ms`, `fps`, `memory_mb`, `device`, `input_shape`.
+Returns `mean_ms`, `std_ms`, `min_ms`, `max_ms`, `p50_ms`, `p95_ms`, `p99_ms`, `fps`, `memory_mb`, `model_id`, `device`, `input_shape`.
 
 ---
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -7,12 +7,8 @@ Fine-tune any supported model on your own depth data with a few lines of Python.
 ## Quick Start
 
 ```python
-from depth_estimation import (
-    DepthAnythingV2Model,
-    DepthTrainer,
-    DepthTrainingArguments,
-    load_dataset,
-)
+from depth_estimation import DepthTrainer, DepthTrainingArguments, load_dataset
+from depth_estimation.models.depth_anything_v2 import DepthAnythingV2Model
 from depth_estimation.data.transforms import get_train_transforms, get_val_transforms
 
 # Load model in training mode

--- a/docs/video.md
+++ b/docs/video.md
@@ -58,7 +58,7 @@ Standard keys (`model_type`, `backbone`, `device`, `latency_seconds`, `input_res
 
 | Source | Example | Description |
 |---|---|---|
-| Video file | `"video.mp4"` | Any format OpenCV can read: `.mp4`, `.avi`, `.mov`, `.mkv`, `.webm`, `.m4v` |
+| Video file | `"video.mp4"` | Any format OpenCV can read: `.mp4`, `.avi`, `.mov`, `.mkv`, `.webm`, `.m4v`, `.flv`, `.wmv` |
 | Webcam | `0` | Integer device index (0 = default camera) |
 | Frame glob | `"frames/*.png"` | Must contain `*` or `?`; files are sorted alphabetically |
 

--- a/src/depth_estimation/cli.py
+++ b/src/depth_estimation/cli.py
@@ -17,7 +17,7 @@ from typing import List, Optional
 # Helpers
 # ---------------------------------------------------------------------------
 
-VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"}
+VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm", ".m4v", ".flv", ".wmv"}
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".webp"}
 
 


### PR DESCRIPTION
## Summary

**1. Broken import example (real bug, not a typo)**
README.md and `docs/training.md`'s Quick Start both showed `from depth_estimation import DepthAnythingV2Model, ...` — confirmed this actually raises `ImportError` (`DepthAnythingV2Model` was never wired into `__init__.py`'s lazy `__getattr__`). Only 2 occurrences of this pattern exist (not a systemic design gap — `trainer.py`'s own docstring doesn't have it), so fixing the docs to match the current working API was the right call over expanding `__init__.py`'s top-level surface for a two-line problem. Fixed to the two-line form already used correctly by `examples/train_depth_anything.py` and `examples/test_finetuned.py`.

**2 & 3. Two undocumented real parameters/return keys**
- `docs/evaluation.md`: `compare()`'s `print_table` param and `profile_latency()`'s `half` param + `model_id` return key exist in the actual code but weren't documented.
- `docs/video.md`: listed supported video extensions as `.mp4/.avi/.mov/.mkv/.webm/.m4v`, missing `.flv`/`.wmv` that `video.py`'s `_VIDEO_EXTENSIONS` actually supports.

**4. Real functional bug (not just docs) — found while checking #3**
`cli.py`'s own `VIDEO_EXTENSIONS` set was missing `.m4v` (present in `video.py`'s equivalent `_VIDEO_EXTENSIONS`) — `depth-estimate predict some.m4v` would silently misroute to the image-collection path and fail with `"No images found"` instead of processing it as video.

## Test plan
- [x] Verified `from depth_estimation.models.depth_anything_v2 import DepthAnythingV2Model` actually works (the broken form doesn't).
- [x] Full fast suite (370 tests) passes, `ruff check .` clean.