### PR TITLE
Add examples/optimize.py; fix 3 real bugs it surfaced

### DIFF
--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -39,11 +39,13 @@ quantize_model(model: nn.Module, dtype: str = "float16") -> nn.Module
 | Argument | Type | Default | Description |
 |---|---|---|---|
 | `model` | `nn.Module` | **required** | Any model. |
-| `dtype` | `str` | `"float16"` | `"float16"` or `"bfloat16"` — a simple precision cast, every parameter/buffer affected, structure unchanged. Intended for GPU inference (float16 on CPU is slow/partially unsupported for many ops in vanilla PyTorch). Or `"int8"` — dynamic quantization of `nn.Linear` layers only, via `torch.quantization.quantize_dynamic`; intended for CPU inference, no calibration data needed. |
+| `dtype` | `str` | `"float16"` | `"float16"` or `"bfloat16"` — a simple precision cast, every parameter/buffer affected, structure unchanged. Intended for GPU inference (float16 on CPU is slow/partially unsupported for many ops in vanilla PyTorch). Or `"int8"` — dynamic quantization of `nn.Linear` layers only, via `torch.quantization.quantize_dynamic`. **Always runs on CPU**, regardless of what device the model is on — see below. |
 
 **Return value depends on `dtype`** — this is the one thing to watch:
-- `"float16"`/`"bfloat16"`: returns `model`, mutated in-place.
-- `"int8"`: returns a **new** model (verified: `result is model` → `False`, though `type(result) is type(model)` holds). The original `model` argument is left unmodified — dynamic quantization replaces `nn.Linear` instances with quantized equivalents rather than mutating them. Don't chain further calls assuming it's the same object.
+- `"float16"`/`"bfloat16"`: returns `model`, mutated in-place, on whatever device it was already on.
+- `"int8"`: returns a **new** model, always on CPU (verified: `result is model` → `False`, though `type(result) is type(model)` holds). The original `model` argument is left completely unmodified, including its device even if it was on GPU. Don't chain further calls assuming it's the same object or the same device.
+
+**`"int8"` always runs on CPU, even if you call it on a GPU-resident model** — confirmed the hard way: `torch.quantization.quantize_dynamic`'s output only has CPU kernels for the quantized linear op it produces. Calling it on a CUDA model raises `NotImplementedError: Could not run 'quantized::linear_dynamic' with arguments from the 'CUDA' backend`, and — this part is easy to miss — simply moving the *already-quantized* result to CPU afterward doesn't fix it either (`apply_dynamic is not implemented for this packed parameter type`). `quantize_model()`/`model.quantize()` handle this for you: they deep-copy the model, move the copy to CPU, then quantize — so you never hit this, and your original GPU-resident model is untouched.
 
 Also available as `model.quantize(dtype=...)` (`BaseDepthModel.quantize()`), with the same return-value caveat.
 

--- a/examples/optimize.py
+++ b/examples/optimize.py
@@ -1,0 +1,189 @@
+"""
+Optimize a model for deployment: prune, quantize, and export to ONNX.
+
+Demonstrates the three model-optimization utilities together — see
+docs/pruning.md, docs/quantization.md, and docs/export.md for the full
+reference on each.
+
+Usage
+-----
+# Export only (no pruning/quantization):
+python examples/optimize.py --model depth-anything-v2-vits --output model.onnx
+
+# Prune 30% of weights, then export:
+python examples/optimize.py --model depth-anything-v2-vits --prune 0.3 --output pruned.onnx
+
+# Prune, then quantize the exported ONNX graph to uint8:
+python examples/optimize.py --model depth-anything-v2-vits --prune 0.3 \\
+    --quantize-onnx uint8 --output optimized.onnx
+
+# float16 cast before export (GPU-oriented — see docs/quantization.md):
+python examples/optimize.py --model depth-anything-v2-vits --quantize-dtype float16 \\
+    --output model_fp16.onnx
+
+Requires the optional `onnx` package: pip install "depth-estimation[export]"
+(and `onnxruntime` for --verify / --quantize-onnx).
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Prune, quantize, and export a depth model to ONNX."
+    )
+    p.add_argument(
+        "--model",
+        default="depth-anything-v2-vits",
+        help="Model variant to optimize (default: depth-anything-v2-vits)",
+    )
+    p.add_argument(
+        "--output",
+        default="model.onnx",
+        help="Destination .onnx file path (default: model.onnx)",
+    )
+    p.add_argument(
+        "--prune",
+        type=float,
+        default=None,
+        metavar="AMOUNT",
+        help="Prune this fraction of weights (e.g. 0.3) before quantizing/exporting. "
+        "Skipped by default.",
+    )
+    p.add_argument(
+        "--quantize-dtype",
+        choices=["float16", "bfloat16", "int8"],
+        default=None,
+        help="In-process PyTorch precision cast/quantization, applied before export. "
+        "Skipped by default. NOTE: 'int8' here is NOT usable in this script — "
+        "its output can't be exported to ONNX at all (no symbolic mapping for "
+        "the op it produces); use --quantize-onnx for ONNX-compatible int8/"
+        "uint8 instead. See docs/quantization.md.",
+    )
+    p.add_argument(
+        "--quantize-onnx",
+        choices=["uint8", "int8", "int16", "uint16"],
+        default=None,
+        metavar="WEIGHT_TYPE",
+        help="Post-export ONNX Runtime quantization (broader op coverage than "
+        "--quantize-dtype, e.g. covers Conv2d). Skipped by default. See "
+        "docs/quantization.md for which weight types are actually verified "
+        "working (int16/uint16 are not).",
+    )
+    p.add_argument(
+        "--input-size",
+        type=int,
+        default=518,
+        help="Spatial size (H=W) for the ONNX export trace (default: 518).",
+    )
+    p.add_argument(
+        "--verify",
+        action="store_true",
+        help="Verify the export (and ONNX quantization, if requested) actually "
+        "matches the source model's output. Requires onnxruntime. Recommended.",
+    )
+    p.add_argument(
+        "--device",
+        default=None,
+        help="Device to load the model on: cuda, cpu, mps. Auto-detected when omitted.",
+    )
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if args.quantize_dtype == "int8":
+        # quantize_model(dtype="int8")'s output cannot be exported to ONNX
+        # at all — torch.onnx.export has no symbolic mapping for the
+        # quantized::linear_dynamic op it produces, at any opset (confirmed:
+        # raises UnsupportedOperatorError). Since this script always exports,
+        # that combination can never work here. See docs/quantization.md.
+        sys.exit(
+            "--quantize-dtype int8 cannot be combined with ONNX export (this "
+            "script always exports) — torch.onnx.export has no symbolic "
+            "mapping for the quantized op it produces. Use --quantize-onnx "
+            "instead (export first, then quantize the ONNX graph), or drop "
+            "--quantize-dtype int8 if you only need a plain PyTorch model. "
+            "See docs/quantization.md."
+        )
+
+    from depth_estimation import AutoDepthModel
+    from depth_estimation.export import export_onnx
+    from depth_estimation.pruning import prune_model, compute_sparsity
+
+    logger.info(f"Loading model: {args.model}")
+    model = AutoDepthModel.from_pretrained(args.model, device=args.device)
+
+    if args.prune is not None:
+        logger.info(f"Pruning {args.prune:.0%} of weights...")
+        prune_model(model, amount=args.prune)
+        sparsity = compute_sparsity(model)["overall"]
+        logger.info(f"Achieved overall sparsity: {sparsity:.3f}")
+
+    export_path = args.output
+    # export_onnx()'s default verify tolerance (atol=rtol=1e-3) is tuned for
+    # float32 round-tripping through the tracer, not for a model already
+    # cast to half precision — confirmed against a real pretrained
+    # checkpoint (depth-anything-v2-vits): a float16 cast produces ~0.005%
+    # of output elements differing by up to ~0.004, comfortably outside
+    # 1e-3 but expected rounding noise for float16 (~3 decimal digits of
+    # precision), not an export bug. Loosen verify's tolerance to match
+    # whenever the model has been cast to half precision beforehand.
+    export_verify_kwargs = {}
+    if args.quantize_dtype in ("float16", "bfloat16"):
+        export_verify_kwargs = {"atol": 1e-2, "rtol": 1e-2}
+
+    if args.quantize_dtype is not None:
+        from depth_estimation.quantization import quantize_model
+
+        logger.info(f"Quantizing (in-process, dtype={args.quantize_dtype})...")
+        model = quantize_model(model, dtype=args.quantize_dtype)
+
+    logger.info(f"Exporting to ONNX (input_size={args.input_size})...")
+    if args.quantize_onnx is not None:
+        # Export to a temp path first, then quantize into the requested output.
+        base_path = export_path + ".pre_quant.onnx"
+        export_onnx(
+            model,
+            base_path,
+            input_size=args.input_size,
+            verify=args.verify,
+            **export_verify_kwargs,
+        )
+
+        from depth_estimation.quantization import quantize_onnx
+
+        logger.info(f"Quantizing exported ONNX graph (weight_type={args.quantize_onnx})...")
+        quantize_onnx(
+            base_path,
+            export_path,
+            weight_type=args.quantize_onnx,
+            verify=args.verify,
+        )
+        os.remove(base_path)
+    else:
+        export_onnx(
+            model,
+            export_path,
+            input_size=args.input_size,
+            verify=args.verify,
+            **export_verify_kwargs,
+        )
+
+    size_mb = os.path.getsize(export_path) / (1024 * 1024)
+    logger.info(f"Done. Saved to {export_path} ({size_mb:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/depth_estimation/export.py
+++ b/src/depth_estimation/export.py
@@ -103,7 +103,19 @@ def export_onnx(
         device = model.device
     else:
         device = next(model.parameters()).device
-    dummy_input = torch.randn(1, 3, input_size, input_size, device=device)
+    # Match the dummy input's dtype to the model's actual parameter dtype
+    # (e.g. float16 after quantize_model(dtype="float16")) — always tracing
+    # with float32 raised "Input type (float) and bias type (c10::Half)
+    # should be the same" against a half-precision model. Same StopIteration
+    # concern as the device lookup above for lazy-net families with no
+    # parameters yet; float32 is the right fallback there since forward()
+    # hasn't run yet to know any better, and it's what those models are
+    # loaded in by default anyway.
+    try:
+        dtype = next(model.parameters()).dtype
+    except StopIteration:
+        dtype = torch.float32
+    dummy_input = torch.randn(1, 3, input_size, input_size, device=device, dtype=dtype)
 
     # Warm-up: some model families (DepthPro, PixelPerfectDepth) lazily
     # build their network on the *first* forward() call rather than in

--- a/src/depth_estimation/modeling_utils.py
+++ b/src/depth_estimation/modeling_utils.py
@@ -323,11 +323,14 @@ class BaseDepthModel(nn.Module):
         Returns:
             For ``"float16"``/``"bfloat16"``: ``self``, mutated in-place
             and returned for chaining.
-            For ``"int8"``: a **new** model — unlike :meth:`prune` and
+            For ``"int8"``: a **new** model, always on CPU regardless of
+            what device ``self`` is on — unlike :meth:`prune` and
             :meth:`export_onnx`, this does *not* return ``self``, since
             dynamic quantization replaces ``nn.Linear`` instances rather
-            than mutating them. Don't chain further calls on this
-            method's return value assuming it's the same object.
+            than mutating them, and torch's dynamic quantization only has
+            CPU kernels. Don't chain further calls on this method's
+            return value assuming it's the same object or the same
+            device.
 
         Example::
 

--- a/src/depth_estimation/quantization.py
+++ b/src/depth_estimation/quantization.py
@@ -1,16 +1,26 @@
 """Precision reduction / quantization for depth estimation models.
 
-Two independent paths, depending on what you're targeting:
+Two independent paths, depending on what you're targeting — **do not mix
+them**: ``quantize_model(dtype="int8")``'s output cannot be exported to
+ONNX at all (see below), so if you want a quantized ONNX file, always
+export first, then quantize with :func:`quantize_onnx`.
 
 - :func:`quantize_model` — in-process PyTorch precision casting/quantization.
   ``"float16"``/``"bfloat16"`` are simple dtype casts (GPU inference
   speedup, halves memory, no accuracy-recovery step needed). ``"int8"``
   uses torch's dynamic quantization of ``nn.Linear`` layers only (CPU
-  inference speedup, no calibration data needed).
+  inference speedup, no calibration data needed) — for **direct PyTorch
+  inference only**. Confirmed: ``export_onnx()`` on an int8-quantized
+  model raises ``UnsupportedOperatorError: Exporting the operator
+  'quantized::linear_dynamic' to ONNX opset version 17 is not
+  supported`` — torch's ONNX exporter has no symbolic mapping for that
+  op at all, regardless of opset.
 - :func:`quantize_onnx` — post-export quantization via ONNX Runtime,
   operating on an already-exported ``.onnx`` file (see
   :mod:`depth_estimation.export`). Broader op coverage than PyTorch's own
-  dynamic quantization (covers ``Conv2d``, not just ``Linear``).
+  dynamic quantization (covers ``Conv2d``, not just ``Linear``). **This
+  is the correct path if you want a quantized ONNX file** — export the
+  unquantized model first, then quantize the resulting ``.onnx``.
 
 Known limitations (verified, not guessed):
     - ``quantize_model(dtype="int8")`` uses ``torch.quantization.quantize_dynamic``,
@@ -43,6 +53,7 @@ Known limitations (verified, not guessed):
       default for CPU execution regardless.
 """
 
+import copy
 import logging
 from pathlib import Path
 from typing import Union
@@ -70,16 +81,26 @@ def quantize_model(model: nn.Module, dtype: str = "float16") -> nn.Module:
             Intended for GPU inference (float16 on CPU is slow/partially
             unsupported in vanilla PyTorch for many ops). Or ``"int8"`` —
             dynamic quantization of ``nn.Linear`` layers only, via
-            ``torch.quantization.quantize_dynamic``; intended for CPU
-            inference, no calibration data needed.
+            ``torch.quantization.quantize_dynamic``. **Always runs on
+            CPU**, regardless of what device ``model`` is on — torch's
+            dynamic quantization only has CPU kernels for the quantized
+            op it produces (confirmed: quantizing a CUDA-resident model
+            directly raises ``NotImplementedError: Could not run
+            'quantized::linear_dynamic' with arguments from the 'CUDA'
+            backend``, and moving the *already-quantized* result to CPU
+            afterward doesn't recover it either). No calibration data
+            needed.
 
     Returns:
         For ``"float16"``/``"bfloat16"``: ``model``, mutated in-place and
         returned for chaining.
-        For ``"int8"``: a **new** model — the original ``model`` argument
-        is left unmodified, since dynamic quantization replaces
-        ``nn.Linear`` instances with quantized equivalents rather than
-        mutating them.
+        For ``"int8"``: a **new** model, always on CPU — the original
+        ``model`` argument is left completely unmodified (including its
+        device, even if it was on GPU), since this deep-copies before
+        moving to CPU and quantizing rather than mutating ``model``
+        in-place. **Not exportable to ONNX** — see this module's
+        docstring; use :func:`quantize_onnx` instead if you need a
+        quantized ``.onnx`` file.
 
     Raises:
         ValueError: For ``"int16"``/``"uint16"`` (not supported by
@@ -91,8 +112,21 @@ def quantize_model(model: nn.Module, dtype: str = "float16") -> nn.Module:
         return model.to(_CAST_DTYPES[dtype])
 
     if dtype == "int8":
+        # torch's dynamic quantization only has CPU kernels for the
+        # quantized linear op it produces (confirmed: quantizing a
+        # CUDA-resident model raises "Could not run 'quantized::
+        # linear_dynamic' with arguments from the 'CUDA' backend", and
+        # simply moving the *quantized* model to CPU afterward doesn't
+        # recover it either — "apply_dynamic is not implemented for this
+        # packed parameter type"). The model must be on CPU *before*
+        # quantizing. Deep-copy first rather than model.to("cpu") directly
+        # — nn.Module.to() mutates and returns self, which would silently
+        # move the caller's original (possibly GPU-resident) model to CPU
+        # as a side effect, contradicting "the original model argument is
+        # left unmodified" below.
+        cpu_model = copy.deepcopy(model).to("cpu")
         return torch.quantization.quantize_dynamic(
-            model, {nn.Linear}, dtype=torch.qint8
+            cpu_model, {nn.Linear}, dtype=torch.qint8
         )
 
     if dtype in ("int16", "uint16"):

--- a/tests/test_export_onnx.py
+++ b/tests/test_export_onnx.py
@@ -114,6 +114,41 @@ class TestExportOnnxFast:
         with pytest.raises(Exception):
             sess.run(None, {"pixel_values": batch})
 
+    def test_float16_model_exports_and_verifies(self, tmp_path):
+        """Regression test: export_onnx() used to always build a float32
+        dummy input regardless of the model's actual dtype, so exporting a
+        model previously cast via quantize_model(dtype="float16") raised
+        RuntimeError: Input type (float) and bias type (c10::Half) should
+        be the same. The dummy input's dtype must track the model's.
+
+        atol/rtol loosened to 1e-2: confirmed against a real pretrained
+        checkpoint that float16's own rounding noise (~3 decimal digits of
+        precision) routinely exceeds export_onnx()'s float32-oriented
+        default of 1e-3 — expected, not an export bug. See
+        examples/optimize.py's matching comment.
+        """
+        from depth_estimation.quantization import quantize_model
+
+        torch.manual_seed(0)
+        config = DepthAnythingV2Config(backbone="vits")
+        model = DepthAnythingV2Model(config).eval()
+        quantize_model(model, dtype="float16")
+        out = tmp_path / "model_fp16.onnx"
+
+        try:
+            export_onnx(model, out, input_size=518, verify=True, atol=1e-2, rtol=1e-2)
+        except RuntimeError as e:
+            # Same known torch-version limitation as
+            # test_quantization.py::test_float16_forward_works — some
+            # torch CPU builds have no Half kernel for conv2d at all.
+            pytest.skip(
+                f"torch {torch.__version__} CPU doesn't implement this op "
+                f"for float16 (known limitation on older torch): {e}"
+            )
+
+        assert out.exists()
+        assert out.stat().st_size > 0
+
     def test_verify_raises_on_real_mismatch(self, tmp_path):
         """verify=True must actually fail when outputs genuinely don't match."""
         from depth_estimation.export import _verify_onnx_export

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -71,6 +71,35 @@ class TestQuantizeModel:
         quantize_model(model, dtype="int8")
         assert next(model.parameters()).dtype == original_dtype
 
+    def test_int8_result_always_on_cpu(self, model):
+        qmodel = quantize_model(model, dtype="int8")
+        assert next(qmodel.parameters()).device == torch.device("cpu")
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a GPU")
+    def test_int8_from_cuda_model_works_and_leaves_original_on_cuda(self, model):
+        """Regression test: torch's dynamic quantization only has CPU
+        kernels for the quantized linear op it produces. Quantizing a
+        CUDA-resident model directly used to either crash immediately
+        (NotImplementedError: 'quantized::linear_dynamic' ... 'CUDA'
+        backend) or, if "fixed" by naively calling model.to("cpu") in
+        quantize_model() itself (an earlier, wrong version of this fix),
+        silently move the CALLER's original model to CPU as a side
+        effect too — nn.Module.to() mutates and returns self. Confirmed
+        both failure modes by hand before landing the deepcopy-based fix
+        below. Only runs where a GPU is actually available (CI is
+        CPU-only), so this won't execute there — verified locally.
+        """
+        cuda_model = model.to("cuda")
+        qmodel = quantize_model(cuda_model, dtype="int8")
+
+        assert next(cuda_model.parameters()).device.type == "cuda"
+
+        dummy = torch.randn(1, 3, 518, 518)
+        with torch.no_grad():
+            out = qmodel(dummy)
+        assert out.shape == (1, 518, 518)
+        assert not torch.isnan(out).any()
+
     def test_int16_raises_with_helpful_message(self, model):
         with pytest.raises(ValueError, match="not supported by PyTorch"):
             quantize_model(model, dtype="int16")
@@ -82,6 +111,20 @@ class TestQuantizeModel:
     def test_unknown_dtype_raises(self, model):
         with pytest.raises(ValueError, match="Unknown dtype"):
             quantize_model(model, dtype="not_a_real_dtype")
+
+    def test_int8_result_cannot_export_to_onnx(self, model, tmp_path):
+        """Documented, confirmed incompatibility: torch's ONNX exporter has
+        no symbolic mapping for the quantized::linear_dynamic op that
+        quantize_model(dtype="int8") produces, at any opset. The correct
+        path for a quantized ONNX file is always export first, then
+        quantize_onnx() — never quantize_model(dtype="int8") then export.
+        """
+        pytest.importorskip("onnx")
+        from depth_estimation.export import export_onnx
+
+        qmodel = quantize_model(model, dtype="int8")
+        with pytest.raises(Exception, match="quantized::linear_dynamic"):
+            export_onnx(qmodel, tmp_path / "should_not_work.onnx", input_size=518)
 
 
 class TestQuantizeOnnx:


### PR DESCRIPTION
## Summary
- Adds `examples/optimize.py` — an end-to-end script demonstrating prune → quantize → export together, following `examples/train_depth_anything.py`'s conventions.
- Writing/running it against a real pretrained checkpoint (`depth-anything-v2-vits`) surfaced 3 real bugs, all fixed here:
  1. **`export_onnx()`**: always built a `float32` dummy trace input regardless of the model's actual dtype, so exporting a model previously cast via `quantize_model(dtype="float16")` raised `RuntimeError: Input type (float) and bias type (c10::Half) should be the same`. Fixed by matching the dummy input's dtype to the model's own parameter dtype (with a `float32` fallback for lazy-net families that have no parameters yet).
  2. **`quantize_model(dtype="int8")`**: crashed with `NotImplementedError` on a CUDA-resident model — torch's dynamic quantization only has CPU kernels for the op it produces. Fixed by deep-copying the model before moving to CPU and quantizing, rather than mutating (and moving) the caller's original model in place.
  3. **`quantize_model(dtype="int8")`'s output can't be exported to ONNX at all** (no symbolic mapping for `quantized::linear_dynamic`, at any opset). Documented clearly in the module docstring, and `examples/optimize.py` now validates this combination early with a clear error instead of crashing deep inside export.
- Also confirmed (against the real pretrained checkpoint) that float16's own rounding noise routinely exceeds `export_onnx()`'s float32-oriented default verify tolerance (`atol=rtol=1e-3`) — not a bug, just expected for half precision. `examples/optimize.py` loosens to `1e-2` for the float16/bfloat16 path; a matching regression test does the same.

## Test plan
- [x] `pytest tests -m "not slow"` — 409 passed, 1 skipped (known older-torch float16-CPU-kernel limitation), 0 failed
- [x] `ruff check .` — clean
- [x] `examples/optimize.py --model depth-anything-v2-vits --prune 0.3 --quantize-onnx uint8 --verify` — real run, succeeded
- [x] `examples/optimize.py --model depth-anything-v2-vits --quantize-dtype float16 --verify` — real run, succeeded (previously crashed)
- [x] New regression tests added for all 3 bugs (`tests/test_export_onnx.py`, `tests/test_quantization.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)