### PR TITLE
Add CONTRIBUTING.md, advisory mypy CI, Dependabot, CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+# Static security analysis via GitHub's CodeQL. Runs on every push/PR to
+# main plus a weekly schedule (to catch newly-published CodeQL query
+# updates against unchanged code), matching this repo's other workflows'
+# trigger conventions (see test.yml, slow-tests.yml).
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Every Monday at 05:00 UTC (offset from slow-tests.yml's 04:00 run).
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v6.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: python
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:python"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,29 @@ jobs:
       - name: Run ruff check
         run: ruff check .
 
+  typecheck:
+    name: typecheck (mypy, advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.1.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install mypy
+        run: python -m pip install mypy
+
+      # Advisory only: the codebase currently has ~290 pre-existing type
+      # errors (see pyproject.toml's [tool.mypy] comment) — not fixed yet,
+      # so this job reports but never fails the build. Remove
+      # `continue-on-error` once the backlog is cleared and this should gate.
+      - name: Run mypy
+        continue-on-error: true
+        run: python -m mypy src/depth_estimation
+
   build:
     name: build (smoke test)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for considering a contribution to `depth_estimation`. This document covers the practical setup — for adding a new model family specifically, see [docs/adding_a_model.md](docs/adding_a_model.md).
+
+## Setup
+
+```bash
+git clone https://github.com/shriarul5273/depth_estimation.git
+cd depth_estimation
+pip install -e ".[dev]"
+```
+
+`[dev]` pulls in `pytest`, `ruff`, `mypy`, and `onnx`/`onnxruntime` (needed for the export/quantization tests) on top of the core runtime dependencies.
+
+## Running tests
+
+The test suite is split into two tiers:
+
+```bash
+# Fast tier — runs on every push/PR, no network access, no real weight downloads
+pytest tests -m "not slow"
+
+# Slow tier — downloads real pretrained weights for all 28 registered model
+# variants from the Hugging Face Hub (several GB), plus a few offline but
+# architecturally heavy cases. Runs weekly in CI, not on every PR.
+pytest tests -m slow
+```
+
+Run the fast tier before opening a PR. The slow tier is useful when your change touches model loading, weight-mapping, or anything else that only a real checkpoint would exercise — expect it to take a while and to use real disk/bandwidth.
+
+## Linting and type checking
+
+```bash
+ruff check .      # must pass — CI gates on this
+mypy src/depth_estimation   # advisory only for now, see below — CI reports but does not gate
+```
+
+The codebase currently has a pre-existing mypy backlog (~290 errors, mostly missing annotations in older modules — see the `[tool.mypy]` comment in `pyproject.toml`). CI runs mypy but doesn't fail the build on it yet. New code should still aim to be clean under `mypy src/depth_estimation` where practical; don't feel obligated to fix unrelated pre-existing errors in files you're only touching in passing.
+
+## Code style
+
+- No comments that restate what the code does — only add one when the *why* isn't obvious from the code itself (a subtle invariant, a workaround for a specific bug, a non-obvious version constraint).
+- Prefer small, focused changes over speculative abstractions. Don't add configurability or error handling for cases that can't currently happen.
+- Match the surrounding module's existing patterns (e.g. how other model families structure `configuration_*.py`/`modeling_*.py`, how other CLI subcommands are wired up) rather than introducing a new convention for one file.
+- Claims in docstrings and `docs/*.md` should be verified against actual behavior, not assumed — several bugs in this project were caught specifically because a documented number (a file size, an error message, a supported version) didn't match what actually ran.
+
+## Pull requests
+
+- Keep PRs scoped to one concern where possible.
+- Include the test command(s) you ran and their result in the PR description.
+- CI (lint, typecheck, build smoke test, and the fast test matrix across Python 3.10–3.12 × several torch versions) must be green before merge.
+
+## Reporting bugs / requesting features
+
+Open an issue at [github.com/shriarul5273/depth_estimation/issues](https://github.com/shriarul5273/depth_estimation/issues). For bugs, include the model variant, torch/Python versions, and a minimal reproduction if you can.
+
+## License
+
+By contributing, you agree your contributions are licensed under this project's [MIT License](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "pytest-cov",
     "onnx>=1.14",
     "onnxruntime",
+    "mypy>=1.10",
 ]
 export = [
     "onnx>=1.14",
@@ -75,3 +76,12 @@ markers = [
 # (they call MODEL_REGISTRY.register(...) at import time) — not because
 # their names are used directly here.
 "src/depth_estimation/__init__.py" = ["F401"]
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+# The codebase currently has ~290 pre-existing type errors (mostly missing
+# annotations in older modules, not real bugs — verified by spot-checking
+# several by hand). Fixing all of them is a separate, large effort; CI runs
+# mypy in advisory (non-blocking) mode for now — see .github/workflows/test.yml.
+# New code should still aim to be clean under this config.


### PR DESCRIPTION
## Summary
Remaining items from the repo-improvement punch list (ONNX export/pruning/quantization support already landed in #14/#17/#18):

- **CONTRIBUTING.md** — setup instructions, the two test tiers (`-m "not slow"` vs `-m slow`), lint/typecheck commands, code style conventions actually followed in this repo, PR expectations.
- **mypy** — added to `[dev]` extras with a `[tool.mypy]` config (`ignore_missing_imports = true`, floor Python 3.10). Wired into CI as a new `typecheck` job. **Advisory only** (`continue-on-error: true`) — ran it locally first: ~290 pre-existing errors across 40/71 source files. Spot-checked several (`cli.py`'s "missing return statement", `marigold_dc`'s `"None" has no attribute` chain) — all missing-annotation gaps, not real bugs (e.g. `_die()` calls `sys.exit()` but isn't typed `NoReturn`). Full cleanup is a separate, large effort; this makes the signal visible without blocking merges on it.
- **Dependabot** — weekly `pip` + `github-actions` update checks.
- **CodeQL** — Python static analysis, push/PR + weekly schedule, matching this repo's existing workflow conventions (concurrency group, action pin style).

## Test plan
- [x] `ruff check .` — clean
- [x] `pytest tests -m "not slow"` — 409 passed, 1 skipped, 0 failed (no regression from these changes)
- [x] `mypy src/depth_estimation` — runs, reports the known ~290-error backlog, confirmed `continue-on-error` keeps it non-blocking
- [x] All new/modified workflow YAML validated with `yaml.safe_load`
- [ ] CI on this PR (lint/typecheck/build/test matrix + the new CodeQL workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)