### PR TITLE
Skip vggt-commercial gracefully when its gated HF repo isn't authorized

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -98,7 +98,9 @@
 | Variant ID | Backbone | Source | Inference | CLI | Trainable |
 |---|---|---|:---:|:---:|:---:|
 | `vggt` | ViT-L | `facebook/VGGT-1B` | ✅ | ✅ | ✅ |
-| `vggt-commercial` | ViT-L | `facebook/VGGT-1B-Commercial` | ✅ | ✅ | ✅ |
+| `vggt-commercial` | ViT-L | `facebook/VGGT-1B-Commercial` | ✅⁴ | ✅⁴ | ✅⁴ |
+
+⁴ Gated on Hugging Face — downloading requires a logged-in `huggingface-hub` session that has accepted the repo's license at its Hugging Face page (set `HF_TOKEN`, or run `huggingface-cli login`). Without this, loading raises `GatedRepoError` (401 Unauthorized). Confirmed: this is the only variant of the 28 that fails in this package's own scheduled slow-test CI run, precisely because that runner has no such login configured.
 
 ---
 

--- a/tests/test_inference_all_models.py
+++ b/tests/test_inference_all_models.py
@@ -109,7 +109,24 @@ class TestPretrainedVariants:
     def test_variant_inference(self, variant_id):
         from depth_estimation import pipeline
 
-        pipe = pipeline("depth-estimation", model=variant_id, device="cpu")
+        try:
+            pipe = pipeline("depth-estimation", model=variant_id, device="cpu")
+        except Exception as e:
+            # vggt-commercial's repo is gated on Hugging Face (confirmed:
+            # raises huggingface_hub.errors.GatedRepoError, a 401) —
+            # downloading it requires a logged-in huggingface-hub session
+            # that has already accepted the repo's license, which this CI
+            # runner doesn't have configured. Not a code bug — see
+            # docs/models.md's footnote on this variant. Skip rather than
+            # fail so this one credential-gated variant doesn't mask a real
+            # regression in the other 27.
+            if "gated" in str(e).lower() or "GatedRepoError" in type(e).__name__:
+                pytest.skip(
+                    f"{variant_id} is a gated Hugging Face repo — requires "
+                    f"authenticated access with the repo's license accepted, "
+                    f"not configured in this environment: {e}"
+                )
+            raise
         result = pipe(_random_image())
         assert isinstance(result, DepthOutput)
         assert result.depth.ndim == 2


### PR DESCRIPTION
## Summary
Triggered the weekly "Slow tests" workflow (28-variant real pretrained tier) via `workflow_dispatch` to actually exercise it. Result: **1 failed, 31 passed** — https://github.com/shriarul5273/depth_estimation/actions/runs/29178970331

The one failure is `vggt-commercial`, whose backing repo (`facebook/VGGT-1B-Commercial`) is **gated** on Hugging Face:
```
E   huggingface_hub.errors.GatedRepoError: 401 Client Error.
E   Cannot access gated repo for url https://huggingface.co/facebook/VGGT-1B-Commercial/...
E   Access to model facebook/VGGT-1B-Commercial is restricted. You must have access to it and be authenticated to access it.
```
Not a code bug — downloading this specific variant requires a `huggingface-hub` login that has already accepted the repo's license, which no CI runner has configured (and shouldn't need to, to validate the other 27 variants).

## Changes
- `tests/test_inference_all_models.py`: `TestPretrainedVariants::test_variant_inference` now catches `GatedRepoError` specifically (by exception type name and "gated" in the message — not swallowing unrelated failures) and skips with a clear reason, instead of failing the whole slow-test run.
- `docs/models.md`: added a footnote on the `vggt-commercial` row documenting the gating requirement, confirmed against the real error.

## Test plan
- [x] Confirmed the exact exception type/message from the real CI failure log (not guessed)
- [x] `ruff check .` — clean
- [x] `pytest tests/test_inference_all_models.py -m "not slow"` — 4 passed (fast tier unaffected)
- [ ] Next scheduled/triggered `Slow tests` run should show 32 passed (or 31 passed + 1 skipped, if `HF_TOKEN` still isn't configured with license acceptance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)