### PR TITLE
Fix 7 real bugs found via GPU + real-image export/prune/quantize testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ export_onnx(model, "depth_anything_v2_vitb.onnx", input_size=518, verify=True)
 depth-estimate export --model depth-anything-v2-vitb --output model.onnx --verify
 ```
 
-Verified working for `depth-anything-v2`, `depth-anything-v3`, and `depth-pro`. Requires the optional `onnx` package: `pip install "depth-estimation[export]"`. See [docs/export.md](https://github.com/shriarul5273/depth_estimation/blob/main/docs/export.md) for supported models and known limitations.
+Verified working for `depth-anything-v1/v2/v3`, `depth-pro`, and `moge`. `zoedepth` and `marigold-dc` are **not exportable** (both wrap an opaque external pipeline) — `export_onnx()` raises a clear error immediately rather than a doomed attempt. Requires the optional `onnx` package: `pip install "depth-estimation[export]"`. GPU inference on the exported file works too via `onnxruntime-gpu`. See [docs/export.md](https://github.com/shriarul5273/depth_estimation/blob/main/docs/export.md) for the full supported-models table, known limitations, and GPU setup.
 
 </details>
 
@@ -304,10 +304,10 @@ model = AutoDepthModel.from_pretrained("depth-anything-v2-vitb")
 model.quantize(dtype="float16")   # in-place GPU precision cast
 
 model.export_onnx("model.onnx")
-quantize_onnx("model.onnx", "model_uint8.onnx", verify=True)  # default weight_type="uint8"
+quantize_onnx("model.onnx", "model_uint8.onnx")  # default weight_type="uint8", verify=True
 ```
 
-See [docs/quantization.md](https://github.com/shriarul5273/depth_estimation/blob/main/docs/quantization.md) — including which formats are actually verified working (`int16`/`uint16` are **not**, despite being accepted by the underlying APIs, and `int8` needs `onnxruntime>=1.26.0` for models with `Conv2d` layers).
+`verify` defaults to `True` — quantization accuracy is **model-dependent, not reliably safe**: testing across the 28 registered variants found `uint8` produces badly wrong output for several real pretrained checkpoints, not just an edge case. See [docs/quantization.md](https://github.com/shriarul5273/depth_estimation/blob/main/docs/quantization.md) — including which formats are actually verified working (`int16`/`uint16` are **not**, despite being accepted by the underlying APIs, and `int8` needs `onnxruntime>=1.26.0` for models with `Conv2d` layers).
 
 </details>
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,18 +191,26 @@ depth-estimate export --model MODEL --output OUTPUT [OPTIONS]
 | `--input-size N` | `518` | Spatial size (H=W) of the dummy input used to trace the graph. Must be a size the model supports (e.g. a multiple of its patch size). |
 | `--opset N` | `17` | ONNX opset version. |
 | `--no-dynamic-batch` | off | Fix the exported graph to batch size 1 instead of allowing any batch size. |
-| `--dynamic-spatial` | off | Allow variable H/W in the exported graph. Many model families have constraints on input size that this doesn't validate — leave off unless you've confirmed the target model tolerates arbitrary sizes. |
-| `--verify` | off | Run the same input through PyTorch and the exported ONNX graph (via `onnxruntime`) and fail if they don't match. Recommended — it's the only way to catch a model that doesn't export correctly. |
+| `--dynamic-spatial` | off | Allow variable H/W in the exported graph. **Confirmed unsafe for DINOv2-backed families** (`depth-anything-v1/v2`, `moge`, and likely others) even though it doesn't error at export time — it silently bakes in a wrong trace-time constant and the exported graph only actually works at the exact shape it was traced with. Leave off unless you've confirmed the target model tolerates arbitrary sizes. |
+| `--verify` | off | Run the same input through PyTorch and the exported ONNX graph (via `onnxruntime`) and fail if they don't match. Recommended — it's the only way to catch a model that doesn't export correctly. On GPU, this correctly accounts for cuDNN's TF32 mode so it doesn't spuriously fail (or pass with far looser real agreement than the tolerance implies). |
 
 #### Verified working
 
-`depth-anything-v2`, `depth-anything-v3`, `depth-pro` — numerically verified to match the PyTorch model.
+`depth-anything-v1/v2/v3`, `depth-pro`, `moge-v1`/`moge-v2-*` — numerically verified to match the PyTorch model.
+
+#### Not exportable at all
+
+`zoedepth` and `marigold-dc` both wrap an opaque external pipeline (`transformers`/`diffusers`) internally — confirmed neither is meaningfully traceable. The CLI will fail immediately with a clear error rather than attempting a doomed export.
 
 #### Known limitation
 
-`pixel-perfect-depth` (and likely `marigold-dc`) sample random noise inside their diffusion `forward()` pass. Tracing freezes that noise as a constant, so the exported graph reuses the same noise every call instead of sampling fresh randomness — export succeeds without error but the output won't match PyTorch. `--verify` catches this.
+`pixel-perfect-depth` samples random noise inside its diffusion `forward()` pass. Tracing freezes that noise as a constant, so the exported graph reuses the same noise every call instead of sampling fresh randomness — export succeeds without error but the output won't match PyTorch. `--verify` catches this.
+
+`moge` recovers an optimal focal length/depth shift via a non-differentiable NumPy solve that also gets frozen at trace time — but deterministically, so `--verify` (which reuses the same input for both sides) won't catch it. The exported model won't recompute this correction for a different real image at deployment time.
 
 Models using `scaled_dot_product_attention` (`depth-anything-v3-*`, `pixel-perfect-depth`, `moge`, `vggt`, `omnivggt`) require a torch version whose ONNX exporter supports that op — added in a later torch release than this package's floor (`torch>=2.0`). `depth-anything-v2` and `depth-pro` are unaffected.
+
+See [docs/export.md](export.md) for the full details, including GPU inference on the exported file via `onnxruntime-gpu`.
 
 #### Examples
 

--- a/docs/export.md
+++ b/docs/export.md
@@ -64,16 +64,18 @@ Returns `output_path` as a `Path`.
 
 ## Supported Models
 
-Verified numerically — output compared against the PyTorch model, not just "export didn't crash":
+Verified numerically — output compared against the PyTorch model, not just "export didn't crash". All of the following was confirmed by running the full prune → export → ONNX inference → quantize pipeline against real pretrained weights and a real (non-square) photo, on both CPU and a real GPU — not just synthetic square test images:
 
 | Family | Status |
 |---|---|
-| `depth-anything-v2` | ✅ Verified (all backbones) |
-| `depth-anything-v3` | ✅ Verified (`depth-anything-v3-small`; requires torch with `scaled_dot_product_attention` ONNX support — see below) |
+| `depth-anything-v1`, `depth-anything-v2` | ✅ Verified (all backbones) |
+| `depth-anything-v3` | ✅ Verified (most variants; `-giant`/`-nested-giant-large` need more VRAM than an 8GB GPU has alongside a live PyTorch model — not an export bug, see [GPU ONNX Inference](#gpu-onnx-inference-onnxruntime-gpu)); requires torch with `scaled_dot_product_attention` ONNX support — see below |
 | `depth-pro` | ✅ Verified |
+| `moge-v1`, `moge-v2-*` | ✅ Verified — but see [MoGe's `onnx_compatible_mode`](#moges-onnx_compatible_mode) below for a real caveat about its focal/shift recovery step |
 | `pixel-perfect-depth` | ⚠️ Exports without error but output does **not** match PyTorch — see below |
-| `marigold-dc` | ⚠️ Likely the same limitation as `pixel-perfect-depth` (not independently tested — needs a real download to exercise) |
-| `moge`, `vggt`, `omnivggt`, `midas`, `zoedepth` | Not tested — `moge`/`vggt`/`omnivggt` need real pretrained weights to construct at all (no offline random-weight path); `midas`/`zoedepth` wrap other libraries. Same `scaled_dot_product_attention` torch-version requirement applies to `moge`/`vggt`/`omnivggt`. |
+| `marigold-dc`, `zoedepth` | ❌ **Not exportable at all** — `export_onnx()` raises `NotImplementedError` immediately rather than attempting a doomed trace. See [Opaque-pipeline models](#opaque-pipeline-models-are-not-exportable) below. |
+| `midas-dpt-large`, `midas-dpt-hybrid`, `midas-beit-large` | Inference (non-export) confirmed working on real non-square images. Export itself hasn't been independently verified. |
+| `vggt`, `omnivggt` | Not tested — need real pretrained weights to construct at all (no offline random-weight path), and (for `vggt`) more VRAM than fits alongside a live PyTorch model on an 8GB GPU. Same `scaled_dot_product_attention` requirement as `moge`. |
 
 ## Known Limitations
 
@@ -81,9 +83,41 @@ Verified numerically — output compared against the PyTorch model, not just "ex
 
 `pixel-perfect-depth` calls `torch.randn(...)` inside its diffusion sampling loop to generate the initial noise. `torch.onnx.export` traces the model by running it once and recording the operations — a random call executed during that one trace gets **frozen as a constant** in the exported graph. The result: the ONNX model always reuses that one fixed noise sample instead of drawing fresh randomness on every call, so its output is structurally different from the PyTorch model (which samples new noise each time).
 
-This isn't a bug you can work around with export options — it would require changing `PixelPerfectDepthModel.forward()`'s public signature to accept noise as an explicit input, which is a real API change outside the scope of `export_onnx()` itself. `marigold-dc` likely has the same issue (also diffusion-based) but hasn't been independently confirmed.
+This isn't a bug you can work around with export options — it would require changing `PixelPerfectDepthModel.forward()`'s public signature to accept noise as an explicit input, which is a real API change outside the scope of `export_onnx()` itself.
 
-**Always use `verify=True` for these families** — it will raise on the mismatch rather than silently handing you a broken export.
+**Always use `verify=True` for this family** — it will raise on the mismatch rather than silently handing you a broken export.
+
+### Opaque-pipeline models are not exportable
+
+`zoedepth` and `marigold-dc` both wrap an opaque external pipeline (`transformers.pipeline()` / `diffusers.MarigoldDepthPipeline`) internally and round-trip the input tensor through PIL/numpy inside `forward()`, rather than staying in pure differentiable PyTorch ops. Confirmed neither is meaningfully traceable:
+
+- **`zoedepth`** crashes *during* tracing with `AttributeError: 'Tensor' object has no attribute 'astype'` — a real bug inside `transformers`' `ZoeDepthImageProcessor` that only manifests under `torch.onnx.export`'s tracing context (normal eager inference is unaffected; `np.round()` on a traced value returns a `Tensor` instead of a plain scalar, and the processor calls `.astype()` on it).
+- **`marigold-dc`**'s trace "succeeds" with no error, but the resulting graph has **zero declared inputs** — the pixel tensor gets converted to a PIL image via `.numpy()` before any traceable op uses it, so the tracer never connects any op back to the actual input. The exported `.onnx` file would just replay one memorized output regardless of what image it's given — not merely inaccurate (like `pixel-perfect-depth` above), completely useless.
+
+`BaseDepthModel._onnx_exportable = False` is set on both classes; `export_onnx()` checks this immediately and raises `NotImplementedError` before attempting any trace, rather than surfacing a confusing third-party crash or wasting time on `marigold-dc`'s (real) diffusion sampling only to discover the result is useless. If you hit the zero-input pattern on some *other* model in the future, `export_onnx()` also detects it generically after tracing and raises a clear `RuntimeError` rather than the confusing `IndexError` onnxruntime gives you otherwise.
+
+### MoGe's `onnx_compatible_mode`
+
+`moge-v1`/`moge-v2-*` use several ops with no ONNX symbolic mapping at opset 17: antialiased bicubic/bilinear resizing (`aten::_upsample_{bicubic,bilinear}2d_aa`), an in-place bitwise AND (`aten::__iand_`), and `autocast`-induced mixed fp16/fp32 dtypes baked into the graph. `export_onnx()` automatically sets `model.onnx_compatible_mode = True` before tracing for any model that defines this flag (currently just `moge`), which swaps these out for exportable equivalents.
+
+Separately, both MoGe versions recover an optimal focal length/depth shift via a **non-differentiable NumPy Gauss-Newton solve** inside `infer()`. That gets frozen as a constant at trace time — the same category of issue as `pixel-perfect-depth`'s frozen noise, except deterministic, so `verify=True` (which reuses the same input for both sides of the comparison) **cannot catch it**: the exported model will not recompute this correction for a genuinely different image at deployment time, even though `verify` passes cleanly. There's no current fix for this beyond being aware of it — it would require reimplementing the Gauss-Newton solve in pure differentiable PyTorch.
+
+### `dynamic_spatial=True` is unsafe for DINOv2-backed models
+
+It doesn't error at export time, but silently produces a broken graph. DINOv2's position-embedding interpolation is skipped via a Python conditional — `if npatch == N and w == h: return pos_embed` — that the tracer resolves once, against the square dummy input, baking in "skip interpolation" as a constant regardless of `dynamic_axes`. The exported graph then only actually works at the exact square shape it was traced with; feeding it any other shape raises a broadcast shape error deep in the graph:
+
+```
+Non-zero status code returned while running Add node ... Attempting to
+broadcast an axis by a dimension other than 1. 1370 by 1407
+```
+
+not a clear "dynamic_spatial unsupported" message — and the PyTorch model itself handles the same non-square input just fine, so this is purely an export limitation, not a real model constraint. Affects `depth-anything-v1`/`v2`, `moge`, and likely other DINOv2-backed families. Leave `dynamic_spatial=False` (the default) for these.
+
+### TF32 can make `verify=True` misleading on GPU
+
+cuDNN's TF32 mode (default-on for Ampere+ GPUs, including anything from the last several NVIDIA generations) trades precision for speed on conv/matmul ops. Confirmed: on a real pretrained+pruned model, TF32 alone pushed the max output difference between PyTorch and the exported ONNX graph to **~0.19** — dwarfing `verify`'s default `1e-3` tolerance — versus **~8e-5** with TF32 off. onnxruntime's CPU execution provider always computes in full FP32, so a GPU-resident PyTorch model compared against it isn't a fair comparison unless TF32 is accounted for.
+
+`export_onnx()` handles this for you: `verify=True`'s internal comparison forward pass runs with `torch.backends.cudnn.allow_tf32` temporarily disabled, then restores your original setting afterward. You don't need to do anything — this is just why `verify=True` on GPU won't spuriously fail (or pass with far looser real agreement than the tolerance implies) the way it used to.
 
 ### `scaled_dot_product_attention` requires a newer torch
 
@@ -96,7 +130,29 @@ torch.onnx.errors.UnsupportedOperatorError: Exporting the operator
 
 regardless of `opset_version`. Upgrade torch if you hit this. `depth-anything-v2` and `depth-pro` are unaffected — they use an older manual-attention implementation that doesn't call `scaled_dot_product_attention`.
 
+## GPU ONNX Inference (`onnxruntime-gpu`)
+
+Everything above uses `onnxruntime`'s CPU execution provider (`verify=True` always does, by design, for a stable comparison baseline). For actual GPU inference on the exported `.onnx` file, install `onnxruntime-gpu` instead of (not alongside) plain `onnxruntime` — they share the same importable `onnxruntime` module and installing one after the other silently leaves whichever was installed last active:
+
+```bash
+pip uninstall -y onnxruntime onnxruntime-gpu
+pip install onnxruntime-gpu
+```
+
+```python
+import onnxruntime as ort
+
+sess = ort.InferenceSession(
+    "model.onnx", providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
+)
+print(sess.get_providers())  # confirm CUDAExecutionProvider is actually active
+```
+
+Confirmed working end-to-end on a real GPU across multiple model families (`depth-anything-v1/v2/v3`, `moge`) — both the unquantized and `uint8`-quantized graphs ran correctly under `CUDAExecutionProvider`. `CPUExecutionProvider` is listed as a fallback: onnxruntime silently falls back per-node to CPU for any op the CUDA provider doesn't implement, so keeping it in the list avoids a hard failure for edge cases rather than causing one.
+
 ## Design Notes
 
 - **`dynamo` pinning**: `torch.onnx.export`'s `dynamo` kwarg didn't exist before roughly torch 2.5, and its *default* value later flipped from `False` (legacy TorchScript-based tracer) to `True` (newer `torch.export`-based exporter). `export_onnx()` pins it to `False` whenever the kwarg is available, so export behavior is consistent across the whole supported torch range instead of silently depending on whichever exporter a given torch release happens to default to.
 - **Warm-up forward pass**: some families (`depth-pro`, `pixel-perfect-depth`) lazily build their network on the *first* `forward()` call rather than in `__init__`. If that first call happens during tracing, the module's parameter set changes mid-trace and `torch.onnx.export` raises `"state_dict changed after running the tracer"`. `export_onnx()` always runs one eager forward pass before tracing to force that lazy init to already be done — harmless for every family, not just the lazy ones.
+- **`_onnx_exportable` opt-out**: any `BaseDepthModel` subclass can set the class attribute `_onnx_exportable = False` to have `export_onnx()` reject it immediately with a clear message, instead of a confusing failure partway through tracing. Currently set on `ZoeDepthModel` and `MarigoldDCModel` — see [Opaque-pipeline models](#opaque-pipeline-models-are-not-exportable) above.
+- **`onnx_compatible_mode` opt-in**: any model can expose a settable `onnx_compatible_mode` property; `export_onnx()` sets it to `True` before tracing if present (a no-op for every model that doesn't define it). Use this to route around ops with no ONNX symbolic mapping — see [MoGe's `onnx_compatible_mode`](#moges-onnx_compatible_mode) above for the reference implementation.

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -74,6 +74,8 @@ quantize_onnx(
 
 File size reduction is consistent (~3.5-4×) even where accuracy isn't — e.g. `depth-anything-v2-vits` went from 99.0 MB to 27.1 MB. Size reduction alone doesn't tell you whether the quantized model is usable; always check `verify`.
 
+Quantized `.onnx` files run under `CUDAExecutionProvider` too, not just CPU — confirmed working end-to-end on a real GPU. See [GPU ONNX Inference](export.md#gpu-onnx-inference-onnxruntime-gpu) in the export docs.
+
 ## Known Limitations
 
 ### `quantize_onnx(weight_type="uint8")` accuracy is model-dependent, not reliably safe

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -17,7 +17,7 @@ qmodel = quantize_model(model, dtype="int8")  # returns a NEW model, see below
 
 # Post-export ONNX Runtime quantization — broader op coverage (covers Conv2d too)
 model.export_onnx("model.onnx")
-quantize_onnx("model.onnx", "model_uint8.onnx", verify=True)  # default weight_type="uint8"
+quantize_onnx("model.onnx", "model_uint8.onnx")  # default weight_type="uint8", verify=True
 ```
 
 ## Which path should I use?
@@ -26,7 +26,7 @@ quantize_onnx("model.onnx", "model_uint8.onnx", verify=True)  # default weight_t
 |---|---|---|
 | Operates on | A PyTorch model, in-process | An already-exported `.onnx` file |
 | `float16`/`bfloat16` | ✅ Simple dtype cast, every layer | Not applicable — export first at your target precision instead |
-| `int8`/`uint8` | ✅ `nn.Linear` only | `uint8` verified working end-to-end. `int8` on a model with `Conv2d` layers (every model in this package has one, in its patch embedding) requires `onnxruntime>=1.26.0` — older CPU builds (e.g. `1.23.2`, the newest available for Python 3.10 at time of writing) don't implement the `ConvInteger` op it produces. See [Known Limitations](#known-limitations). |
+| `int8`/`uint8` | ✅ `nn.Linear` only | `uint8`'s accuracy is **model-dependent** — good for some checkpoints, badly wrong for others (see [Known Limitations](#known-limitations)); always use `verify=True` (the default). `int8` on a model with `Conv2d` layers (every model in this package has one, in its patch embedding) requires `onnxruntime>=1.26.0` — older CPU builds (e.g. `1.23.2`, the newest available for Python 3.10 at time of writing) don't implement the `ConvInteger` op it produces. |
 | `int16`/`uint16` | ❌ Not supported by PyTorch's quantization at all | ⚠️ Accepted by the API but the resulting model commonly **fails to load** — see [Known Limitations](#known-limitations) |
 | Calibration data needed | No | No (uses dynamic quantization) |
 
@@ -58,7 +58,7 @@ quantize_onnx(
     onnx_path: str | Path,
     output_path: str | Path,
     weight_type: str = "uint8",
-    verify: bool = False,
+    verify: bool = True,
     atol: float = 5e-2,
     rtol: float = 5e-2,
 ) -> Path
@@ -68,13 +68,19 @@ quantize_onnx(
 |---|---|---|---|
 | `onnx_path` | `str` or `Path` | **required** | Path to an existing `.onnx` file — e.g. from [`export_onnx()`](export.md). |
 | `output_path` | `str` or `Path` | **required** | Destination for the quantized `.onnx` file. |
-| `weight_type` | `str` | `"uint8"` | `"uint8"` (default — verified working end-to-end, and ONNX Runtime's own recommended default for CPU execution) or `"int8"` (needs `onnxruntime>=1.26.0` for models with `Conv2d` layers — see [Known Limitations](#known-limitations)). `"int16"`/`"uint16"` accepted but see [Known Limitations](#known-limitations). |
-| `verify` | `bool` | `False` | Load the quantized model in an `onnxruntime.InferenceSession` and run one forward pass, raising if it fails to load/run or if the output diverges from the original beyond `atol`/`rtol`. **Recommended** — this is what actually caught the limitations below, rather than silently shipping a broken file. |
+| `weight_type` | `str` | `"uint8"` | `"uint8"` (default — ONNX Runtime's own recommended default for CPU execution) or `"int8"` (needs `onnxruntime>=1.26.0` for models with `Conv2d` layers — see [Known Limitations](#known-limitations)). `"int16"`/`"uint16"` accepted but see [Known Limitations](#known-limitations). **Accuracy is model-dependent regardless of which you pick** — see below. |
+| `verify` | `bool` | `True` | Load the quantized model in an `onnxruntime.InferenceSession` and run one forward pass, raising if it fails to load/run or if the output diverges from the original beyond `atol`/`rtol`. Defaults to `True` (changed from `False`) after finding `uint8` produces badly wrong output for several real pretrained models — see [Known Limitations](#known-limitations). Only set `False` once you've already confirmed accuracy for your specific model. |
 | `atol`, `rtol` | `float` | `5e-2` | Tolerances for `verify`'s output comparison. Looser than `export_onnx()`'s `verify` (`1e-3`) since quantization is lossy by design. |
 
-Confirmed on `depth-anything-v2-vits`: `int8`/`uint8` quantization reduced the exported ONNX file size from 94.2 MB to 25.6 MB (3.7×).
+File size reduction is consistent (~3.5-4×) even where accuracy isn't — e.g. `depth-anything-v2-vits` went from 99.0 MB to 27.1 MB. Size reduction alone doesn't tell you whether the quantized model is usable; always check `verify`.
 
 ## Known Limitations
+
+### `quantize_onnx(weight_type="uint8")` accuracy is model-dependent, not reliably safe
+
+Testing across all 28 registered model variants (not just one) found that `uint8` dynamic quantization produces badly wrong output for 7 of them — e.g. `depth-anything-v1-vitb`: 100% of output elements outside the default 5% tolerance, with output magnitude nearly doubled versus the unquantized model. Confirmed this is **not** a pruning interaction (reproduces on an unpruned model too) and not a bug in this package's code — naive dynamic quantization (no calibration data) is simply a poor fit for some real weight distributions. `int8` shares the same underlying quantization mechanism and is expected to have the same risk.
+
+This is why `verify` now defaults to `True` — always check accuracy for your specific model rather than assuming `uint8` (or any weight type) is safe based on it having worked for a different model.
 
 ### `quantize_model(dtype="int8")` uses a deprecated PyTorch API
 

--- a/src/depth_estimation/export.py
+++ b/src/depth_estimation/export.py
@@ -9,14 +9,34 @@ Usage::
     export_onnx(model, "depth_anything_v2_vitb.onnx", input_size=518, verify=True)
 
 Known limitations:
-    - Diffusion-based models (``pixel-perfect-depth``, and likely
-      ``marigold-dc``) sample internal random noise inside ``forward()``.
-      Tracing freezes that call's result as a constant in the exported
-      graph, so the ONNX model always reuses the same noise instead of
-      sampling fresh randomness per call — the export "succeeds" but
-      produces materially different output than the PyTorch model. Do
-      not export these families for production use; ``verify=True``
-      will catch this (it'll raise on the numerical mismatch).
+    - ``pixel-perfect-depth`` (diffusion-based) samples internal random
+      noise inside ``forward()``. Tracing freezes that call's result as a
+      constant in the exported graph, so the ONNX model always reuses the
+      same noise instead of sampling fresh randomness per call — the
+      export "succeeds" but produces materially different output than the
+      PyTorch model. Do not export this family for production use;
+      ``verify=True`` will catch it (raises on the numerical mismatch).
+    - ``zoedepth`` and ``marigold-dc`` wrap an opaque external pipeline
+      (HuggingFace ``transformers``/``diffusers``) and round-trip through
+      PIL/numpy inside ``forward()`` — confirmed not traceable at all:
+      ``export_onnx()`` raises ``NotImplementedError`` immediately for
+      these (``BaseDepthModel._onnx_exportable = False``) rather than
+      attempting a doomed trace. ZoeDepth crashes mid-trace on a real bug
+      in ``transformers``' image processor that only manifests under
+      tracing; Marigold-DC's trace "succeeds" but produces a graph with
+      zero declared inputs (a static replay of one memorized output).
+    - ``moge`` (v1 and v2) recovers an optimal focal length/depth shift
+      via a non-differentiable NumPy Gauss-Newton solve inside
+      ``infer()``. That gets frozen as a constant at trace time, same
+      category as the noise-freezing issue above — except it's
+      deterministic, so ``verify=True`` (which reuses the same dummy
+      input for both sides of the comparison) can't catch it the same
+      way: the exported model will not recompute this correction for a
+      *different* real image at deployment time, even though verify
+      passes. Also requires ``moge``'s ``onnx_compatible_mode`` flag
+      (set automatically here) to swap out several ops with no ONNX
+      symbolic mapping at opset 17 (antialiased resize, in-place bitwise
+      ops, autocast-induced mixed fp16/fp32 dtypes).
     - Models using ``F.scaled_dot_product_attention`` in their attention
       blocks (``depth-anything-v3-*``, ``pixel-perfect-depth``, ``moge``,
       ``vggt``, ``omnivggt``) require a torch version whose ONNX exporter
@@ -78,7 +98,21 @@ def export_onnx(
             Many of these architectures have constraints on spatial size
             (multiple-of-patch-size, or an internally fixed resolution like
             DepthPro) — leave this False unless you've confirmed the target
-            model tolerates arbitrary input sizes.
+            model tolerates arbitrary input sizes. **Confirmed unsafe for
+            DINOv2-backed families (depth-anything-v1/v2, moge, and
+            others) even though it doesn't error at export time**: their
+            position-embedding interpolation is skipped via a Python
+            conditional (``if npatch == N and w == h: return pos_embed``)
+            that the tracer resolves once, at trace time, against the
+            square dummy input — baking in "skip interpolation" as a
+            constant regardless of ``dynamic_axes``. The exported graph
+            then only actually works at the exact square shape it was
+            traced with; feeding it any other shape raises a broadcast
+            shape error deep in the graph (e.g. ``right operand cannot
+            broadcast on dim 1``), not a clear "dynamic_spatial
+            unsupported" message. ``verify=True`` with the default square
+            dummy input will not catch this — it only exercises the shape
+            that already works.
         verify: If True, run the same input through both the PyTorch model
             and the exported ONNX graph (via onnxruntime, an optional
             dependency) and assert the outputs match within ``atol``/
@@ -91,10 +125,27 @@ def export_onnx(
     Returns:
         ``output_path``, as a ``Path``.
     """
+    if not getattr(model, "_onnx_exportable", True):
+        raise NotImplementedError(
+            f"{type(model).__name__} wraps an opaque external pipeline "
+            "(HuggingFace transformers/diffusers) and round-trips through "
+            "PIL/numpy inside forward() — confirmed not traceable to ONNX "
+            "(ZoeDepth crashes mid-trace on a transformers bug that only "
+            "manifests under tracing; Marigold-DC 'succeeds' but produces "
+            "a graph with zero declared inputs). Not supported."
+        )
+
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     model = model.eval()
+    # Opt-in hook: some model families (confirmed: MoGe) expose an
+    # onnx_compatible_mode flag that swaps out ops with no ONNX symbolic
+    # mapping at the current opset (e.g. antialiased bicubic/bilinear
+    # resize — aten::_upsample_{bicubic,bilinear}2d_aa) for an exportable
+    # equivalent. Harmless no-op for every model that doesn't define it.
+    if hasattr(model, "onnx_compatible_mode"):
+        model.onnx_compatible_mode = True
     # Prefer BaseDepthModel.device: some families (DepthPro,
     # PixelPerfectDepth) have no parameters at all until their lazily-built
     # network exists, so next(model.parameters()) raises StopIteration
@@ -157,6 +208,32 @@ def export_onnx(
             **export_kwargs,
         )
 
+    # Some model families (confirmed: marigold-dc) convert pixel_values to
+    # PIL/numpy *inside* forward() before doing anything traceable with it —
+    # the tracer then has no traced op depending on the actual input tensor,
+    # so torch.onnx.export "succeeds" but silently produces a graph with
+    # zero declared inputs: a static replay of one memorized output,
+    # regardless of what's fed to it at inference time. That's a materially
+    # different (and worse) failure than the documented frozen-random-noise
+    # limitation below — it's not merely inaccurate, the exported model is
+    # unusable for any image but the one it happened to trace with. Catch
+    # it here with a clear error rather than letting callers discover it via
+    # a confusing IndexError out of onnxruntime, or silently ship it.
+    import onnx as _onnx
+
+    graph_inputs = _onnx.load(str(output_path)).graph.input
+    if len(graph_inputs) == 0:
+        raise RuntimeError(
+            f"Exported ONNX graph for {type(model).__name__} has zero "
+            "declared inputs — the model likely converts its input tensor "
+            "to PIL/numpy inside forward() before any traceable op uses "
+            "it (confirmed for marigold-dc), so tracing disconnects the "
+            "graph from the actual input entirely. The resulting .onnx "
+            "file would just replay one memorized output regardless of "
+            "what image it's given. This model family is not exportable "
+            "to ONNX with the current tracer-based approach."
+        )
+
     logger.info("Exported ONNX model to %s", output_path)
 
     if verify:
@@ -187,8 +264,21 @@ def _verify_onnx_export(
             "pip install onnxruntime"
         ) from e
 
-    with torch.no_grad():
-        torch_out = model(dummy_input).cpu().numpy()
+    # cuDNN's TF32 mode (default-on for Ampere+ GPUs) trades precision for
+    # speed on conv/matmul — confirmed this alone can push a real
+    # pretrained+pruned model's max output diff to ~0.19 (vs ~8e-5 with it
+    # off), dwarfing the default 1e-3 tolerance and having nothing to do
+    # with actual export fidelity. onnxruntime's CPU execution provider
+    # always computes in full FP32, so compare like-for-like: disable TF32
+    # for this one comparison forward pass, then restore the caller's
+    # setting exactly as it was.
+    prev_tf32 = torch.backends.cudnn.allow_tf32
+    torch.backends.cudnn.allow_tf32 = False
+    try:
+        with torch.no_grad():
+            torch_out = model(dummy_input).cpu().numpy()
+    finally:
+        torch.backends.cudnn.allow_tf32 = prev_tf32
 
     sess = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
     input_name = sess.get_inputs()[0].name

--- a/src/depth_estimation/modeling_utils.py
+++ b/src/depth_estimation/modeling_utils.py
@@ -34,6 +34,17 @@ class BaseDepthModel(nn.Module):
 
     config_class: type = BaseDepthConfig
 
+    # Set False by subclasses that wrap an opaque external pipeline (e.g.
+    # ZoeDepth, Marigold-DC both wrap a HuggingFace/diffusers pipeline
+    # object internally and round-trip through PIL/numpy inside forward())
+    # — confirmed these cannot be meaningfully traced to ONNX: ZoeDepth
+    # crashes mid-trace on a real bug in transformers' image processor that
+    # only manifests under tracing; Marigold-DC "succeeds" but produces a
+    # graph with zero declared inputs (see export.py). export_onnx() checks
+    # this upfront and fails fast with a clear message instead of running
+    # a doomed (and possibly expensive) trace attempt.
+    _onnx_exportable: bool = True
+
     def __init__(self, config: BaseDepthConfig):
         super().__init__()
         self.config = config

--- a/src/depth_estimation/models/marigold_dc/modeling_marigold_dc.py
+++ b/src/depth_estimation/models/marigold_dc/modeling_marigold_dc.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import numpy as np
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 from PIL import Image
 
@@ -52,6 +53,15 @@ class MarigoldDCModel(BaseDepthModel):
     """
 
     config_class = MarigoldDCConfig
+    # Wraps a diffusers MarigoldDepthPipeline and round-trips through
+    # PIL/numpy inside forward() — confirmed the trace "succeeds" but the
+    # tracer never connects any traced op back to the actual pixel_values
+    # input (it's consumed only via a numpy conversion first), producing an
+    # ONNX graph with zero declared inputs: a static replay of one
+    # memorized output regardless of what image it's given. Distinct from
+    # (and more broken than) the already-documented frozen-random-noise
+    # limitation in export.py's module docstring.
+    _onnx_exportable = False
 
     def __init__(self, config: MarigoldDCConfig):
         super().__init__(config)
@@ -84,6 +94,15 @@ class MarigoldDCModel(BaseDepthModel):
         pipe.scheduler = DDIMScheduler.from_config(
             pipe.scheduler.config, timestep_spacing="trailing"
         )
+        # diffusers loads pipeline components with requires_grad=True by
+        # default (ready for fine-tuning), but this wrapper is inference-only
+        # — every other model in this package loads frozen. Left on, this
+        # also crashes ONNX export outright ("Cannot insert a Tensor that
+        # requires grad as a constant"), before even reaching the
+        # already-documented frozen-noise limitation below.
+        for component in vars(pipe).values():
+            if isinstance(component, nn.Module):
+                component.requires_grad_(False)
         self._pipe = pipe
 
     def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:

--- a/src/depth_estimation/models/midas/configuration_midas.py
+++ b/src/depth_estimation/models/midas/configuration_midas.py
@@ -40,12 +40,26 @@ class MiDaSConfig(BaseDepthConfig):
         backbone: str = "dpt-large",
         input_size: int = 384,
         patch_size: int = 16,
+        keep_aspect_ratio: "bool | None" = None,
         **kwargs,
     ):
+        # dpt-large/dpt-hybrid (HF Intel/dpt-large, Intel/dpt-hybrid-midas)
+        # hardcode a square patch grid internally — confirmed: DepthProcessor's
+        # default aspect-ratio-preserving resize produces a non-square input
+        # on any non-square real image, and these two crash on it
+        # (dpt-hybrid: "Input image size doesn't match model", dpt-large:
+        # a patch-grid reshape assuming a perfect square). beit-large
+        # (Intel/dpt-beit-large-512) has no such issue — different HF
+        # implementation, interpolated position embeddings handle
+        # non-square inputs fine. Only override the default when the
+        # caller hasn't explicitly set keep_aspect_ratio themselves.
+        if keep_aspect_ratio is None:
+            keep_aspect_ratio = backbone == "beit-large"
         super().__init__(
             backbone=backbone,
             input_size=input_size,
             patch_size=patch_size,
+            keep_aspect_ratio=keep_aspect_ratio,
             **kwargs,
         )
 

--- a/src/depth_estimation/models/moge/modeling_moge.py
+++ b/src/depth_estimation/models/moge/modeling_moge.py
@@ -41,6 +41,21 @@ from .configuration_moge import MoGeConfig
 
 logger = logging.getLogger(__name__)
 
+
+def _round_to_int(x) -> int:
+    """round() that also works when x is a Tensor (confirmed: under ONNX
+    tracing, ``img_w / img_h`` here can come out as a 0-d Tensor rather
+    than a plain float — Python's builtin round() then raises TypeError:
+    type Tensor doesn't define __round__ method, since torch.Tensor has
+    no __round__. Static export is the only supported mode anyway (see
+    export_onnx()'s dynamic_spatial caveat), so collapsing to a concrete
+    Python int here is safe.
+    """
+    if torch.is_tensor(x):
+        return int(torch.round(x).item())
+    return round(x)
+
+
 # ═════════════════════════════════════════════════════════════════════════════
 # §1  Minimal utils3d shim (replaces the utils3d package)
 # ═════════════════════════════════════════════════════════════════════════════
@@ -801,7 +816,11 @@ class _DinoVisionTransformer(nn.Module):
         patch_pos_embed = nn.functional.interpolate(
             patch_pos_embed.reshape(1, M, M, dim).permute(0, 3, 1, 2),
             mode="bicubic",
-            antialias=self.interpolate_antialias,
+            # aten::_upsample_bicubic2d_aa has no ONNX symbolic mapping at
+            # opset 17 (confirmed) — disable antialiasing under
+            # onnx_compatible_mode, same as every other antialias call in
+            # this file.
+            antialias=self.interpolate_antialias and not self.onnx_compatible_mode,
             **kwargs,
         )
         assert (h0, w0) == patch_pos_embed.shape[-2:]
@@ -1746,12 +1765,28 @@ class _MoGeModelV1(nn.Module):
             raise ValueError(f"Invalid remap_output: {self.remap_output}")
         return points
 
+    @property
+    def onnx_compatible_mode(self):
+        return getattr(self, "_onnx_compatible_mode", False)
+
+    @onnx_compatible_mode.setter
+    def onnx_compatible_mode(self, value):
+        self._onnx_compatible_mode = value
+
     def forward(self, image, num_tokens):
         oh, ow = image.shape[-2:]
         resize_factor = ((num_tokens * 196) / (oh * ow)) ** 0.5
         rh, rw = int(oh * resize_factor), int(ow * resize_factor)
+        # antialias=True bicubic upsampling is aten::_upsample_bicubic2d_aa,
+        # unsupported at ONNX opset 17 (confirmed: UnsupportedOperatorError).
+        # Disable it under onnx_compatible_mode — slightly different output
+        # (no anti-aliasing), but exportable.
         image = F.interpolate(
-            image, (rh, rw), mode="bicubic", align_corners=False, antialias=True
+            image,
+            (rh, rw),
+            mode="bicubic",
+            align_corners=False,
+            antialias=not self.onnx_compatible_mode,
         )
         image = (image - self.image_mean) / self.image_std
         image_14 = F.interpolate(
@@ -1759,7 +1794,7 @@ class _MoGeModelV1(nn.Module):
             (rh // 14 * 14, rw // 14 * 14),
             mode="bilinear",
             align_corners=False,
-            antialias=True,
+            antialias=not self.onnx_compatible_mode,
         )
         features = self.backbone.get_intermediate_layers(
             image_14, self.intermediate_layers, return_class_token=True
@@ -1802,7 +1837,12 @@ class _MoGeModelV1(nn.Module):
         with torch.autocast(
             device_type=self.device.type,
             dtype=torch.float16,
-            enabled=use_fp16 and self.dtype != torch.float16,
+            # Tracing under autocast can bake mixed fp16/fp32 dtypes into
+            # the exported graph inconsistently (confirmed: onnxruntime
+            # then refuses to load it — "Type parameter (T) of Optype
+            # (ConvTranspose) bound to different types"). Disable under
+            # onnx_compatible_mode.
+            enabled=use_fp16 and self.dtype != torch.float16 and not self.onnx_compatible_mode,
         ):
             output = self.forward(image, num_tokens)
         points, mask = output["points"], output["mask"]
@@ -1946,8 +1986,8 @@ class _MoGeModelV2(nn.Module):
         B, _, img_h, img_w = image.shape
         dtype, device = image.dtype, image.device
         aspect_ratio = img_w / img_h
-        base_h = round((num_tokens / aspect_ratio) ** 0.5)
-        base_w = round((num_tokens * aspect_ratio) ** 0.5)
+        base_h = _round_to_int((num_tokens / aspect_ratio) ** 0.5)
+        base_w = _round_to_int((num_tokens * aspect_ratio) ** 0.5)
 
         features, cls_token = self.encoder(
             image, base_h, base_w, return_class_token=True
@@ -2033,7 +2073,12 @@ class _MoGeModelV2(nn.Module):
         with torch.autocast(
             device_type=self.device.type,
             dtype=torch.float16,
-            enabled=use_fp16 and self.dtype != torch.float16,
+            # Tracing under autocast can bake mixed fp16/fp32 dtypes into
+            # the exported graph inconsistently (confirmed: onnxruntime
+            # then refuses to load it — "Type parameter (T) of Optype
+            # (ConvTranspose) bound to different types"). Disable under
+            # onnx_compatible_mode.
+            enabled=use_fp16 and self.dtype != torch.float16 and not self.onnx_compatible_mode,
         ):
             output = self.forward(image, num_tokens=num_tokens)
 
@@ -2072,7 +2117,10 @@ class _MoGeModelV2(nn.Module):
 
                 depth = points[..., 2] + shift[..., None, None]
                 if mask_binary is not None:
-                    mask_binary &= depth > 0
+                    # In-place &= is aten::__iand_, unsupported at ONNX
+                    # opset 17 (confirmed). Out-of-place & is identical
+                    # semantically and exports fine.
+                    mask_binary = mask_binary & (depth > 0)
             else:
                 depth = None
 
@@ -2117,6 +2165,14 @@ class MoGeModel(BaseDepthModel):
     def __init__(self, config: MoGeConfig):
         super().__init__(config)
         self._net = None  # set by _load_pretrained_weights
+
+    @property
+    def onnx_compatible_mode(self):
+        return getattr(self._net, "onnx_compatible_mode", False)
+
+    @onnx_compatible_mode.setter
+    def onnx_compatible_mode(self, value):
+        self._net.onnx_compatible_mode = value
 
     def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
         """Run depth estimation.

--- a/src/depth_estimation/models/zoedepth/modeling_zoedepth.py
+++ b/src/depth_estimation/models/zoedepth/modeling_zoedepth.py
@@ -31,6 +31,14 @@ class ZoeDepthModel(BaseDepthModel):
     """
 
     config_class = ZoeDepthConfig
+    # Wraps an opaque HF transformers.Pipeline and round-trips through PIL
+    # inside forward() — confirmed not traceable to ONNX: crashes mid-trace
+    # on a real bug in transformers' ZoeDepthImageProcessor that only
+    # manifests under torch.onnx.export's tracing context (np.round() on a
+    # traced value returns a Tensor instead of a plain scalar, and the
+    # processor calls .astype() on it — works fine in normal eager
+    # inference, only breaks under tracing).
+    _onnx_exportable = False
 
     def __init__(self, config: ZoeDepthConfig):
         super().__init__(config)

--- a/src/depth_estimation/processing_utils.py
+++ b/src/depth_estimation/processing_utils.py
@@ -48,6 +48,11 @@ class DepthProcessor:
         self.patch_size = config.patch_size
         self.mean = config.mean
         self.std = config.std
+        # True (default) for every model confirmed to tolerate arbitrary
+        # aspect ratios. MiDaS's dpt-large/dpt-hybrid variants set this
+        # False — confirmed they crash on a non-square resize (their HF
+        # backbone hardcodes a square patch grid internally).
+        self.keep_aspect_ratio = getattr(config, "keep_aspect_ratio", True)
 
     @classmethod
     def from_config(cls, config: BaseDepthConfig) -> "DepthProcessor":
@@ -219,16 +224,21 @@ class DepthProcessor:
         h, w = image_rgb.shape[:2]
         target = self.input_size
 
-        # Compute scale so shorter side >= target
-        scale = target / min(h, w)
-        new_h = int(h * scale)
-        new_w = int(w * scale)
+        if self.keep_aspect_ratio:
+            # Compute scale so shorter side >= target
+            scale = target / min(h, w)
+            new_h = int(h * scale)
+            new_w = int(w * scale)
 
-        # Ensure dimensions are multiples of patch_size
-        new_h = new_h - (new_h % self.patch_size)
-        new_w = new_w - (new_w % self.patch_size)
-        new_h = max(new_h, self.patch_size)
-        new_w = max(new_w, self.patch_size)
+            # Ensure dimensions are multiples of patch_size
+            new_h = new_h - (new_h % self.patch_size)
+            new_w = new_w - (new_w % self.patch_size)
+            new_h = max(new_h, self.patch_size)
+            new_w = max(new_w, self.patch_size)
+        else:
+            # Fixed square resize, ignoring aspect ratio — required by
+            # backbones that hardcode a square patch grid (see __init__).
+            new_h = new_w = target
 
         resized = cv2.resize(image_rgb, (new_w, new_h), interpolation=cv2.INTER_CUBIC)
 

--- a/src/depth_estimation/quantization.py
+++ b/src/depth_estimation/quantization.py
@@ -23,6 +23,17 @@ export first, then quantize with :func:`quantize_onnx`.
   unquantized model first, then quantize the resulting ``.onnx``.
 
 Known limitations (verified, not guessed):
+    - ``quantize_onnx()``'s ``uint8`` accuracy is **model-dependent, not
+      reliably safe across the board**. Testing across the 28 registered
+      variants (not just the one model this was originally checked
+      against) found 7 of them produce badly wrong quantized output —
+      e.g. ``depth-anything-v1-vitb``: 100% of output elements outside
+      the default 5% tolerance, magnitude nearly doubled. Not a pruning
+      interaction (reproduces on an unpruned model too) and not a code
+      bug — naive dynamic quantization (no calibration data) is simply a
+      poor fit for some real weight distributions. This is why
+      ``verify`` now defaults to ``True``: always check accuracy for your
+      specific model rather than assuming ``uint8`` is safe.
     - ``quantize_model(dtype="int8")`` uses ``torch.quantization.quantize_dynamic``,
       which is **deprecated** as of recent torch releases in favor of
       ``torchao``. This package doesn't migrate to ``torchao`` yet, since
@@ -149,7 +160,7 @@ def quantize_onnx(
     onnx_path: Union[str, Path],
     output_path: Union[str, Path],
     weight_type: str = "uint8",
-    verify: bool = False,
+    verify: bool = True,
     atol: float = 5e-2,
     rtol: float = 5e-2,
 ) -> Path:
@@ -160,25 +171,33 @@ def quantize_onnx(
         onnx_path: Path to an existing ``.onnx`` file, e.g. from
             :func:`depth_estimation.export.export_onnx`.
         output_path: Destination for the quantized ``.onnx`` file.
-        weight_type: ``"uint8"`` (default — verified working end-to-end,
-            and ONNX Runtime's own recommended default for CPU execution)
-            or ``"int8"`` — for a model with ``Conv2d`` layers (every
-            model in this package has one, in its patch embedding),
-            ``"int8"`` produces a ``ConvInteger`` op that requires
-            ``onnxruntime>=1.26.0``; older CPU builds (confirmed:
+        weight_type: ``"uint8"`` (default — ONNX Runtime's own recommended
+            default for CPU execution, and the only weight type broadly
+            supported at all) or ``"int8"`` — for a model with ``Conv2d``
+            layers (every model in this package has one, in its patch
+            embedding), ``"int8"`` produces a ``ConvInteger`` op that
+            requires ``onnxruntime>=1.26.0``; older CPU builds (confirmed:
             ``1.23.2``, the newest available for Python 3.10 at time of
             writing) raise ``NOT_IMPLEMENTED``. ``"int16"``/``"uint16"``
             are accepted but commonly fail to *load* afterward in ONNX
             Runtime's CPU execution provider regardless of version — see
-            this module's docstring. Use ``verify=True`` to catch any of
-            this rather than silently producing a broken file.
-        verify: If True, load the quantized model in an
+            this module's docstring. **Quantization accuracy is
+            model-dependent, not just weight-type-dependent**: testing
+            across the 28 registered variants found ``uint8`` produces
+            badly wrong output (100% of elements outside tolerance, up to
+            ~2x magnitude error) for several real pretrained checkpoints,
+            not just an edge case — this is why ``verify`` defaults to
+            True.
+        verify: If True (the default — changed from False after the
+            finding above), load the quantized model in an
             ``onnxruntime.InferenceSession`` and run one forward pass
             with random input, raising if it fails to load/run, or if
             the output doesn't loosely match the original ``onnx_path``
             model's output (quantization is lossy by design, so the
             tolerance here is much looser than
             :func:`~depth_estimation.export.export_onnx`'s ``verify``).
+            Set False only if you've already confirmed accuracy for your
+            specific model and want to skip the extra forward pass.
         atol, rtol: Tolerances for ``verify``'s output comparison.
 
     Returns:
@@ -188,6 +207,10 @@ def quantize_onnx(
         ValueError: For an unrecognized ``weight_type``.
         ImportError: If the optional ``onnxruntime`` package isn't
             installed.
+        AssertionError: If ``verify=True`` and the quantized output
+            diverges beyond ``atol``/``rtol`` — this is a real,
+            model-dependent risk (see ``weight_type`` above), not a rare
+            edge case.
     """
     if weight_type not in _ONNX_WEIGHT_TYPES:
         raise ValueError(

--- a/tests/test_export_onnx.py
+++ b/tests/test_export_onnx.py
@@ -167,6 +167,72 @@ class TestExportOnnxFast:
         with pytest.raises(AssertionError):
             _verify_onnx_export(different_model, out, dummy_input=dummy)
 
+    def test_onnx_exportable_false_blocks_export_immediately(self, tmp_path):
+        """Regression test: BaseDepthModel._onnx_exportable = False (set by
+        ZoeDepth and Marigold-DC, both of which wrap an opaque external
+        pipeline and round-trip through PIL/numpy inside forward() —
+        confirmed neither is meaningfully traceable) must raise
+        immediately, before attempting any trace, rather than surfacing a
+        confusing crash deep inside a third-party library or wasting time
+        on a doomed export attempt.
+        """
+        from depth_estimation.modeling_utils import BaseDepthModel
+        from depth_estimation.configuration_utils import BaseDepthConfig
+
+        class _NotExportable(BaseDepthModel):
+            _onnx_exportable = False
+
+            def forward(self, pixel_values):
+                return pixel_values.mean(dim=1)
+
+        model = _NotExportable(BaseDepthConfig()).eval()
+        with pytest.raises(NotImplementedError, match="not traceable"):
+            export_onnx(model, tmp_path / "should_not_exist.onnx", input_size=64)
+        assert not (tmp_path / "should_not_exist.onnx").exists()
+
+    def test_verify_restores_tf32_setting(self, tmp_path):
+        """Regression test: _verify_onnx_export() disables cuDNN TF32
+        for its comparison forward pass (confirmed: on a real
+        pretrained+pruned GPU model, TF32 alone pushed max diff to ~0.19,
+        vs ~8e-5 with it off — dwarfing the default 1e-3 tolerance and
+        having nothing to do with actual export fidelity). It must
+        restore the caller's original setting afterward rather than
+        leaving it globally disabled as a side effect.
+        """
+        torch.manual_seed(0)
+        config = DepthAnythingV2Config(backbone="vits")
+        model = DepthAnythingV2Model(config).eval()
+        out = tmp_path / "model.onnx"
+
+        for original in (True, False):
+            torch.backends.cudnn.allow_tf32 = original
+            export_onnx(model, out, input_size=518, verify=True)
+            assert torch.backends.cudnn.allow_tf32 is original
+
+    def test_zero_input_graph_detected(self, tmp_path):
+        """Regression test: a model that consumes pixel_values only via a
+        non-traceable conversion (e.g. .numpy(), disconnecting it from the
+        graph before any traced op uses it — confirmed for marigold-dc)
+        produces an ONNX graph with zero declared inputs: a static replay
+        of one memorized output regardless of what image it's given.
+        export_onnx() must catch this with a clear error rather than
+        silently writing a useless file, or letting callers discover it
+        via a confusing IndexError out of onnxruntime.
+        """
+        from depth_estimation.modeling_utils import BaseDepthModel
+        from depth_estimation.configuration_utils import BaseDepthConfig
+
+        class _DisconnectedInput(BaseDepthModel):
+            def forward(self, pixel_values):
+                # Round-trips through numpy, same disconnection pattern as
+                # marigold-dc/zoedepth's PIL conversion.
+                arr = pixel_values.detach().cpu().numpy()
+                return torch.from_numpy(arr).mean(dim=1)
+
+        model = _DisconnectedInput(BaseDepthConfig()).eval()
+        with pytest.raises(RuntimeError, match="zero declared inputs"):
+            export_onnx(model, tmp_path / "should_not_exist.onnx", input_size=64)
+
 
 @pytest.mark.slow
 class TestExportOnnxSlowOffline:
@@ -204,3 +270,100 @@ class TestExportOnnxSlowOffline:
         dummy = torch.randn(1, 3, 128, 128)
         with pytest.raises(AssertionError):
             _verify_onnx_export(model, out, dummy_input=dummy)
+
+
+@pytest.mark.slow
+class TestExportOnnxRealPretrained:
+    """Requires real pretrained weights from the Hugging Face Hub (network
+    required) — same tier as TestPretrainedVariants in
+    test_inference_all_models.py.
+    """
+
+    def test_zoedepth_blocked_immediately(self, tmp_path):
+        """Regression test: ZoeDepthModel wraps an opaque HF
+        transformers.Pipeline and round-trips through PIL inside
+        forward() — confirmed it crashes mid-trace on a real bug in
+        transformers' image processor that only manifests under tracing
+        (np.round() on a traced value returns a Tensor, and the processor
+        calls .astype() on it — works fine in normal eager inference).
+        _onnx_exportable = False must block this immediately instead.
+        """
+        from depth_estimation import AutoDepthModel
+
+        model = AutoDepthModel.from_pretrained("zoedepth", device="cpu")
+        with pytest.raises(NotImplementedError, match="not traceable"):
+            export_onnx(model, tmp_path / "should_not_exist.onnx", input_size=384)
+
+    def test_marigold_dc_blocked_immediately(self, tmp_path):
+        """Regression test: MarigoldDCModel wraps a diffusers pipeline and
+        round-trips through PIL/numpy inside forward(). _onnx_exportable
+        = False must block this immediately rather than running the full
+        (expensive) diffusion sampling process only to then discover the
+        resulting graph has zero declared inputs.
+        """
+        from depth_estimation import AutoDepthModel
+
+        model = AutoDepthModel.from_pretrained("marigold-dc", device="cpu")
+        with pytest.raises(NotImplementedError, match="not traceable"):
+            export_onnx(model, tmp_path / "should_not_exist.onnx", input_size=768)
+
+    def test_marigold_dc_pipeline_components_frozen(self):
+        """Regression test: diffusers loads pipeline components with
+        requires_grad=True by default (ready for fine-tuning) — this
+        wrapper is inference-only and every other model in this package
+        loads frozen. Left on, this crashed ONNX export outright before
+        even reaching the (separately documented) frozen-noise
+        limitation.
+        """
+        from depth_estimation import AutoDepthModel
+
+        model = AutoDepthModel.from_pretrained("marigold-dc", device="cpu")
+        model._ensure_pipe()
+        for name, param in model._pipe.unet.named_parameters():
+            assert not param.requires_grad, f"unet.{name} still requires_grad"
+
+    @pytest.mark.parametrize("model_id", ["moge-v1", "moge-v2-vitb-normal"])
+    def test_moge_exports_and_verifies(self, tmp_path, model_id):
+        """Regression test: moge-v1 used unconditional antialias=True
+        bicubic/bilinear resizing (aten::_upsample_{bicubic,bilinear}2d_aa,
+        unsupported at ONNX opset 17) and moge-v2 called Python's round()
+        on what can be a Tensor under tracing (TypeError: type Tensor
+        doesn't define __round__ method) plus an in-place &= (aten::__iand_,
+        also unsupported) and autocast-induced mixed fp16/fp32 dtypes in
+        the exported graph. export_onnx() now sets the model's
+        onnx_compatible_mode flag (where present) to route around all of
+        these.
+        """
+        from depth_estimation import AutoDepthModel
+
+        model = AutoDepthModel.from_pretrained(model_id, device="cpu")
+        out = tmp_path / "model.onnx"
+        export_onnx(model, out, input_size=518, verify=True)
+        assert out.exists()
+
+    def test_midas_dpt_large_handles_non_square_image(self):
+        """Regression test: dpt-large/dpt-hybrid hardcode a square patch
+        grid internally and crash on DepthProcessor's default
+        aspect-ratio-preserving resize for any non-square real image
+        (confirmed: dpt-large raises a patch-grid reshape error,
+        dpt-hybrid raises "Input image size doesn't match model").
+        MiDaSConfig now defaults keep_aspect_ratio=False for these two
+        variants specifically (beit-large is unaffected and keeps it
+        True).
+        """
+        import numpy as np
+        from depth_estimation import pipeline
+
+        pipe = pipeline("depth-estimation", model="midas-dpt-large", device="cpu")
+        non_square = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+        result = pipe(non_square)
+        assert not np.isnan(result.depth).any()
+
+    def test_midas_dpt_hybrid_handles_non_square_image(self):
+        import numpy as np
+        from depth_estimation import pipeline
+
+        pipe = pipeline("depth-estimation", model="midas-dpt-hybrid", device="cpu")
+        non_square = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+        result = pipe(non_square)
+        assert not np.isnan(result.depth).any()

--- a/tests/test_export_onnx.py
+++ b/tests/test_export_onnx.py
@@ -100,6 +100,39 @@ class TestExportOnnxFast:
         result = sess.run(None, {"pixel_values": batch})[0]
         assert result.shape[0] == 3
 
+    def test_dynamic_spatial_broken_at_nonsquare_shape(self, tmp_path):
+        """Regression test locking in a real, confirmed finding: on
+        DINOv2-backed models, dynamic_spatial=True does NOT error at
+        export time, but the position-embedding-interpolation branch
+        (``if npatch == N and w == h: return pos_embed``) gets resolved
+        once against the square trace-time dummy input and baked in as a
+        constant, regardless of dynamic_axes. Feeding the exported graph
+        any other (non-square) shape then raises a broadcast shape error
+        deep in the graph (confirmed: "Attempting to broadcast an axis by
+        a dimension other than 1. 1370 by 1407") — not a clean
+        "dynamic_spatial unsupported" message, and PyTorch itself handles
+        the same non-square input just fine (this isn't a real model
+        limitation, only an export one).
+        """
+        torch.manual_seed(0)
+        config = DepthAnythingV2Config(backbone="vits")
+        model = DepthAnythingV2Model(config).eval()
+        out = tmp_path / "model.onnx"
+        export_onnx(model, out, input_size=518, dynamic_spatial=True, dynamic_batch=False)
+
+        # A non-square shape, still patch-size-aligned (14), different
+        # from the square 518x518 the graph was traced with.
+        nonsquare_input = torch.randn(1, 3, 518, 532)
+
+        with torch.no_grad():
+            model(nonsquare_input)  # PyTorch itself: no problem.
+
+        sess = onnxruntime.InferenceSession(
+            str(out), providers=["CPUExecutionProvider"]
+        )
+        with pytest.raises(Exception, match="[Bb]roadcast"):
+            sess.run(None, {"pixel_values": nonsquare_input.numpy()})
+
     def test_static_batch_rejects_other_sizes(self, tmp_path):
         torch.manual_seed(0)
         config = DepthAnythingV2Config(backbone="vits")

--- a/tests/test_inference_all_models.py
+++ b/tests/test_inference_all_models.py
@@ -43,25 +43,40 @@ from depth_estimation.models.pixel_perfect_depth.modeling_ppd import (
 )
 
 WIDTH, HEIGHT = 224, 224
+# Deliberately non-square — every model in this suite used to only ever be
+# exercised with a square image (WIDTH == HEIGHT above), which is exactly
+# why the MiDaS dpt-large/dpt-hybrid non-square crash and the
+# dynamic_spatial silent-wrong-output bug (both confirmed against real
+# non-square photos, not synthetic ones) went uncaught for so long. This
+# doesn't need real weights or network, so it belongs in the fast tier —
+# it catches preprocessing/shape-handling bugs generically, even though it
+# can't catch model-weight-dependent issues like quantization accuracy.
+NONSQUARE_WIDTH, NONSQUARE_HEIGHT = 336, 224
 
 
 def _random_image():
     return np.random.randint(0, 255, (HEIGHT, WIDTH, 3), dtype=np.uint8)
 
 
-def _assert_valid_output(result):
+def _random_nonsquare_image():
+    return np.random.randint(
+        0, 255, (NONSQUARE_HEIGHT, NONSQUARE_WIDTH, 3), dtype=np.uint8
+    )
+
+
+def _assert_valid_output(result, height=HEIGHT, width=WIDTH):
     assert isinstance(result, DepthOutput)
-    assert result.depth.shape == (HEIGHT, WIDTH)
-    assert result.colored_depth.shape == (HEIGHT, WIDTH, 3)
+    assert result.depth.shape == (height, width)
+    assert result.colored_depth.shape == (height, width, 3)
     assert not np.isnan(result.depth).any()
     assert result.depth.min() >= 0.0
     assert result.depth.max() <= 1.0
 
 
-def _run_pipeline(config, model):
+def _run_pipeline(config, model, image=None):
     processor = DepthProcessor.from_config(config)
     pipe = DepthPipeline(model=model, processor=processor, device="cpu")
-    return pipe(_random_image())
+    return pipe(image if image is not None else _random_image())
 
 
 class TestFastOffline:
@@ -77,6 +92,19 @@ class TestFastOffline:
         config = DepthAnythingV3Config(backbone="small")
         model = DepthAnythingV3Model(config)
         _assert_valid_output(_run_pipeline(config, model))
+
+    @pytest.mark.parametrize("backbone", ["vits", "vitb", "vitl"])
+    def test_depth_anything_v2_nonsquare_image(self, backbone):
+        config = DepthAnythingV2Config(backbone=backbone)
+        model = DepthAnythingV2Model(config)
+        result = _run_pipeline(config, model, image=_random_nonsquare_image())
+        _assert_valid_output(result, height=NONSQUARE_HEIGHT, width=NONSQUARE_WIDTH)
+
+    def test_depth_anything_v3_small_nonsquare_image(self):
+        config = DepthAnythingV3Config(backbone="small")
+        model = DepthAnythingV3Model(config)
+        result = _run_pipeline(config, model, image=_random_nonsquare_image())
+        _assert_valid_output(result, height=NONSQUARE_HEIGHT, width=NONSQUARE_WIDTH)
 
 
 @pytest.mark.slow

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -142,3 +142,57 @@ class TestFromConfig:
         processor = DepthProcessor.from_config(config)
         assert processor.input_size == 384
         assert processor.patch_size == 16
+
+
+class TestKeepAspectRatio:
+    """Regression tests: MiDaS dpt-large/dpt-hybrid crash on a non-square
+    real image under the default aspect-ratio-preserving resize (confirmed:
+    dpt-hybrid raises "Input image size doesn't match model", dpt-large
+    raises a patch-grid reshape error) — both hardcode a square patch grid
+    internally. keep_aspect_ratio=False makes the processor resize to an
+    exact square instead, matching what these backbones require.
+    """
+
+    def test_default_preserves_aspect_ratio(self, sample_image_rgb):
+        # sample_image_rgb is (480, 640) — not square.
+        config = BaseDepthConfig(input_size=384, patch_size=14)
+        processor = DepthProcessor.from_config(config)
+        assert processor.keep_aspect_ratio is True
+        pixel_values = processor.preprocess(sample_image_rgb)["pixel_values"]
+        assert pixel_values.shape[2] != pixel_values.shape[3]
+
+    def test_keep_aspect_ratio_false_forces_square(self, sample_image_rgb):
+        config = BaseDepthConfig(input_size=384, patch_size=14, keep_aspect_ratio=False)
+        processor = DepthProcessor.from_config(config)
+        assert processor.keep_aspect_ratio is False
+        pixel_values = processor.preprocess(sample_image_rgb)["pixel_values"]
+        assert pixel_values.shape[2] == pixel_values.shape[3] == 384
+
+    def test_midas_dpt_large_defaults_to_square(self):
+        from depth_estimation.models.midas.configuration_midas import MiDaSConfig
+
+        config = MiDaSConfig(backbone="dpt-large")
+        assert config.keep_aspect_ratio is False
+
+    def test_midas_dpt_hybrid_defaults_to_square(self):
+        from depth_estimation.models.midas.configuration_midas import MiDaSConfig
+
+        config = MiDaSConfig(backbone="dpt-hybrid")
+        assert config.keep_aspect_ratio is False
+
+    def test_midas_beit_large_keeps_aspect_ratio(self):
+        """beit-large has no such issue — different HF implementation,
+        interpolated position embeddings handle non-square inputs fine.
+        """
+        from depth_estimation.models.midas.configuration_midas import MiDaSConfig
+
+        config = MiDaSConfig(backbone="beit-large")
+        assert config.keep_aspect_ratio is True
+
+    def test_midas_dpt_large_processor_produces_square_input(self, sample_image_rgb):
+        from depth_estimation.models.midas.configuration_midas import MiDaSConfig
+
+        config = MiDaSConfig(backbone="dpt-large")
+        processor = DepthProcessor.from_config(config)
+        pixel_values = processor.preprocess(sample_image_rgb)["pixel_values"]
+        assert pixel_values.shape[2] == pixel_values.shape[3] == config.input_size

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -193,3 +193,28 @@ class TestQuantizeOnnx:
     def test_unknown_weight_type_raises(self, onnx_path, tmp_path):
         with pytest.raises(ValueError, match="Unknown weight_type"):
             quantize_onnx(onnx_path, tmp_path / "out.onnx", weight_type="fp8")
+
+    def test_verify_defaults_to_true(self, onnx_path, tmp_path):
+        """Regression test: verify used to default to False, meaning
+        quantize_onnx() could silently ship a badly broken quantized file
+        with no error at all. Confirmed real risk, not theoretical:
+        testing across the 28 registered model variants found uint8
+        quantization produces wildly wrong output (100% of elements
+        outside tolerance) for several real pretrained checkpoints.
+        Changed the default to True — this test locks that in by checking
+        the signature's actual default rather than passing verify
+        explicitly, so a regression back to False would be caught.
+        """
+        import inspect
+
+        sig = inspect.signature(quantize_onnx)
+        assert sig.parameters["verify"].default is True
+
+    def test_verify_false_explicitly_skips_check(self, onnx_path, tmp_path):
+        """verify=False must still be honored for callers who've already
+        confirmed accuracy and want to skip the extra forward pass."""
+        pytest.importorskip("onnxruntime")
+        out = tmp_path / "quant_uint8_noverify.onnx"
+        result = quantize_onnx(onnx_path, out, weight_type="uint8", verify=False)
+        assert result == out
+        assert out.exists()

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -175,9 +175,14 @@ class TestQuantizeOnnx:
         assert out.exists()
 
     def test_int8_actually_shrinks_file(self, onnx_path, tmp_path):
+        # verify=False: this test only checks file size, not accuracy —
+        # int8's Conv2d support (ConvInteger) is version-gated (see
+        # test_int8_quantizes_and_verifies) and verify now defaults to
+        # True, which would otherwise fail this on older onnxruntime for
+        # a reason unrelated to what this test actually checks.
         pytest.importorskip("onnxruntime")
         out = tmp_path / "quant_int8.onnx"
-        quantize_onnx(onnx_path, out, weight_type="int8")
+        quantize_onnx(onnx_path, out, weight_type="int8", verify=False)
         assert out.stat().st_size < onnx_path.stat().st_size
 
     def test_int16_verify_raises_known_limitation(self, onnx_path, tmp_path):


### PR DESCRIPTION
## Summary

Ran the full prune → export → ONNX inference → quantize pipeline against a real photo, on a real GPU, across ~20 pretrained model variants (not the synthetic square images the test suite normally uses). Found and fixed 7 real, distinct bugs:

1. **`quantize_onnx(weight_type="uint8")` silently ships badly wrong output** for several real models (100% of elements outside tolerance for `depth-anything-v1-vitb`, magnitude nearly doubled). Confirmed not a pruning interaction, not a code bug — naive dynamic quantization is a poor fit for some real weight distributions. `verify` now defaults to `True` instead of `False`.
2. **`marigold-dc` crashed ONNX export outright** (`Cannot insert a Tensor that requires grad as a constant`) — `diffusers` loads pipeline components with `requires_grad=True` by default; this wrapper is inference-only. Now frozen after loading, like every other model.
3. **`moge-v1`/`v2` export was completely broken**: unconditional `antialias=True` bicubic/bilinear resize (unsupported ONNX ops), Python `round()` called on a value that's a `Tensor` under tracing, an in-place `&=` (also unsupported), and `autocast` baking mixed fp16/fp32 dtypes into the graph. `export_onnx()` now sets the model's `onnx_compatible_mode` flag (already defined in moge's code, just never invoked) before tracing.
4. **`midas-dpt-large`/`dpt-hybrid` crash on any non-square real image** — `DepthProcessor`'s aspect-ratio-preserving resize is incompatible with these two backbones' hardcoded square patch grid. Added a `keep_aspect_ratio` config flag, defaulted `False` for just these two variants (`beit-large` is unaffected).
5. **`zoedepth` and `marigold-dc` both wrap an opaque external pipeline** and round-trip through PIL/numpy inside `forward()` — confirmed neither is meaningfully traceable (`zoedepth` crashes mid-trace on a `transformers` bug that only manifests under tracing; `marigold-dc`'s trace "succeeds" but produces a graph with zero declared inputs). Added `BaseDepthModel._onnx_exportable`, checked upfront in `export_onnx()` to fail fast with a clear message.
6. **`dynamic_spatial=True` silently bakes in a wrong constant** on DINOv2-backed models (skips position-embedding interpolation) rather than erroring — documented the actual failure mode.
7. **`export_onnx(verify=True)` could spuriously fail on GPU**: cuDNN's default-on TF32 alone pushed a real pretrained+pruned model's max diff to ~0.19 vs ~8e-5 with it off, dwarfing the 1e-3 default tolerance. `_verify_onnx_export()` now disables TF32 for its comparison pass and restores the caller's setting afterward.

Also added a general safety net: `export_onnx()` detects a zero-input exported graph (the mechanism behind #5's marigold-dc case) and raises a clear error for any future model family that hits the same pattern, instead of a confusing `IndexError` out of onnxruntime.

## Test plan
- [x] `ruff check .` — clean
- [x] `pytest tests -m "not slow"` — 420 passed, 1 skipped, 0 failed (11 new tests added)
- [x] All 7 new slow-tier regression tests (`TestExportOnnxRealPretrained`) pass against real pretrained weights: `zoedepth`/`marigold-dc` fail-fast, `marigold-dc` gradients frozen, `moge-v1`/`moge-v2-vitb-normal` export+verify, `midas-dpt-large`/`dpt-hybrid` on a real non-square image
- [x] Each fix verified individually against the real failure before being folded into the branch (not guessed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)